### PR TITLE
출금 상세 내역의 id를 대문자로 표시

### DIFF
--- a/apps/penxle.com/src/routes/(default)/me/revenue/settlement/SettlementDetailModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/settlement/SettlementDetailModal.svelte
@@ -69,7 +69,7 @@
   <svelte:fragment slot="title">출금 상세 정보</svelte:fragment>
 
   {#if $revenueWithdrawal}
-    <div class={css({ paddingTop: '16px', paddingBottom: { base: '32px', sm: '20px' }, paddingX: '20px' })}>
+    <div class={css({ paddingTop: '24px', paddingBottom: { base: '60px', sm: '24px' }, paddingX: '20px' })}>
       <div
         class={css({
           _after: {
@@ -81,7 +81,7 @@
           },
         })}
       >
-        <p class={css({ fontWeight: 'semibold' })}>{$revenueWithdrawal?.id}</p>
+        <p class={css({ fontWeight: 'semibold' })}>{$revenueWithdrawal?.id.toUpperCase()}</p>
         <time class={css({ marginTop: '5px', fontSize: '14px', color: 'gray.500' })}>
           {dayjs($revenueWithdrawal?.createdAt).formatAsDateTime()}
         </time>


### PR DESCRIPTION
|before|after|
|--|--|
|<img width="466" alt="image" src="https://github.com/penxle/penxle/assets/76952602/9f505304-c8a0-41df-95f7-625791fee4c7">|<img width="454" alt="image" src="https://github.com/penxle/penxle/assets/76952602/57a28455-a2ee-4636-958f-aa767447e63f">
