### PR TITLE
SharePostPopover에서 style 프로퍼티를 팝오버가 아닌 버튼에 주입하도록 함

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/SharePostPopover.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/SharePostPopover.svelte
@@ -87,7 +87,14 @@
   />
 {/if}
 
-<button aria-controls={id} aria-expanded={open} type="button" on:click={() => (open = !open)} use:anchor>
+<button
+  class={css(style)}
+  aria-controls={id}
+  aria-expanded={open}
+  type="button"
+  on:click={() => (open = !open)}
+  use:anchor
+>
   <slot />
 </button>
 
@@ -97,31 +104,28 @@
     role="region"
     use:floating
     {...$$restProps}
-    class={css(
-      {
-        borderWidth: '1px',
-        borderColor: 'gray.200',
-        borderRadius: '10px',
-        backgroundColor: 'gray.5',
-        sm: {
-          width: '376px',
-          boxShadow: '[0px 6px 18px 0px {colors.gray.900/12}]',
-          zIndex: '2',
-        },
-        smDown: {
-          position: '[fixed!]',
-          top: '[initial!]',
-          bottom: '[0!]',
-          left: '[0!]',
-          right: '[0!]',
-          borderBottomRadius: '0',
-          width: 'full',
-          boxShadow: '[0px 8px 24px 0px {colors.gray.900/28}]',
-          zIndex: '50',
-        },
+    class={css({
+      borderWidth: '1px',
+      borderColor: 'gray.200',
+      borderRadius: '10px',
+      backgroundColor: 'gray.5',
+      sm: {
+        width: '376px',
+        boxShadow: '[0px 6px 18px 0px {colors.gray.900/12}]',
+        zIndex: '2',
       },
-      style,
-    )}
+      smDown: {
+        position: '[fixed!]',
+        top: '[initial!]',
+        bottom: '[0!]',
+        left: '[0!]',
+        right: '[0!]',
+        borderBottomRadius: '0',
+        width: 'full',
+        boxShadow: '[0px 8px 24px 0px {colors.gray.900/28}]',
+        zIndex: '50',
+      },
+    })}
     transition:fade={{ duration: 100 }}
   >
     <header


### PR DESCRIPTION
포스트 공유 팝오버/바텀시트 (`SharePostPopover.svelte`) 에 주입하는 `style` 프로퍼티를 팝오버 자체가 아닌 트리거 버튼에 주입하도록 수정함
