### PR TITLE
모바일에서 피드백 받지 않음 툴팁 위치가 잘못 뜨는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -1035,7 +1035,7 @@
         {/if}
 
         <Tooltip
-          style={flex.raw({ width: 'full', align: 'center', height: 'full' })}
+          style={flex.raw({ align: 'center', height: 'full' })}
           enabled={!$query.post.receiveFeedback}
           message="피드백 받기를 설정하지 않은 포스트예요"
           offset={10}


### PR DESCRIPTION
|before|after|
|--|--|
|<img width="328" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/22557bd0-e8c3-4301-b469-d54e1b264b43">|<img width="423" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/0801c515-c9d1-44ff-87bb-09fbf23eb2cf">
