### PR TITLE
태그 추천 gql 추가

### DIFF
--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -642,6 +642,7 @@ type Query {
   recentlyPurchasedPosts: [Post!]!
   recentlyUsedTags: [Tag!]!
   recommendFeed: [Post!]!
+  recommendedTags: [Tag!]!
   revenueWithdrawal(id: String!): RevenueWithdrawal!
   sampleImage: Image!
   sampleImages: [Image!]!


### PR DESCRIPTION
### TL;DR

사용자에게 태그 추천 기능을 추가하였습니다.

### What changed?

GraphQL 스키마에 recommendedTags 필드를 추가하였고, 이를 처리하기 위한 쿼리 리졸버를 작성하였습니다. 사용자가 최근 본 포스트의 태그 중에서 사용자가 아직 팔로우하지 않은 태그를 추출하여 추천합니다. 추천 태그는 최근 본 포스트에서 가장 많이 사용된 순서대로 정렬됩니다.

### How to test?

추천 태그 쿼리가 의도대로 동작하는지 확인하기 위해, 사용자가 본 포스트에 사용된 태그를 확인하고 해당 태그를 아직 팔로우하지 않았다면 추천 태그 목록에 나타나는지 확인합니다.

### Why make this change?

이 변경은 사용자에게 개인화된 콘텐츠를 제공하기 위한 것입니다. 사용자의 관심사에 맞는 태그를 추천함으로써 사용자 경험을 향상시키고 콘텐트 소비를 촉진하려는 의도입니다.

---

