### PR TITLE
크롬 브라우저에서 컬러 입력 박스에 사각형 보더가 나타나는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/ColorPicker.svelte
+++ b/apps/penxle.com/src/lib/components/ColorPicker.svelte
@@ -241,11 +241,17 @@
       <input
         style:background-color={hex}
         class={css({
-          borderWidth: '1px',
-          borderColor: 'gray.200',
-          borderRadius: 'full',
-          marginRight: '12px',
-          size: '22px',
+          'borderWidth': '1px',
+          'borderColor': 'gray.200',
+          'borderRadius': 'full',
+          'marginRight': '12px',
+          'size': '22px',
+          '&::-webkit-color-swatch-wrapper': {
+            visibility: 'hidden',
+          },
+          '&::-moz-color-swatch': {
+            borderStyle: 'none',
+          },
         })}
         type="color"
         value={hex}
@@ -405,10 +411,5 @@
         0px 0px 3px 0px rgba(0, 0, 0, 0.2),
         0px 1px 10px 0px rgba(0, 0, 0, 0.08);
     }
-  }
-
-  input[type='color']::-moz-color-swatch,
-  input[type='color']::-webkit-color-swatch {
-    border: none;
   }
 </style>


### PR DESCRIPTION
<img width="218" alt="스크린샷 2024-03-22 오후 3 40 09" src="https://github.com/withglyph/glyph/assets/5278201/f74b50fa-5a3a-40a4-b528-19e7025a19be">
