### PR TITLE
태그 상세 페이지에서 포스트 목록이 먼저 보이도록 수정

### DIFF
--- a/apps/penxle.com/src/lib/components/PostCard.svelte
+++ b/apps/penxle.com/src/lib/components/PostCard.svelte
@@ -331,7 +331,7 @@
       )}
     >
       {#each $post.tags.slice(0, 4) as { tag } (tag.id)}
-        <Tag style={css.raw({ maxWidth: '260px' })} href={`/tag/${tag.name}`} size="sm">#{tag.name}</Tag>
+        <Tag style={css.raw({ maxWidth: '260px' })} href={`/tag/${tag.name}/post`} size="sm">#{tag.name}</Tag>
       {/each}
       {#if $post.tags.length > 4}
         <Tag size="sm">+{$post.tags.length - 4}개의 태그</Tag>

--- a/apps/penxle.com/src/lib/components/SpacePostCard.svelte
+++ b/apps/penxle.com/src/lib/components/SpacePostCard.svelte
@@ -231,7 +231,7 @@
     {#if $post.tags}
       <div class={flex({ gap: '6px', flexWrap: 'wrap' })}>
         {#each $post.tags.slice(0, 4) as { tag } (tag.id)}
-          <Tag style={css.raw({ maxWidth: '260px' })} href={`/tag/${tag.name}`} size="sm">#{tag.name}</Tag>
+          <Tag style={css.raw({ maxWidth: '260px' })} href={`/tag/${tag.name}/post`} size="sm">#{tag.name}</Tag>
         {/each}
         {#if $post.tags.length > 4}
           <Tag size="sm">+{$post.tags.length - 4}개의 태그</Tag>

--- a/apps/penxle.com/src/routes/(default)/(index)/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/(index)/+layout.svelte
@@ -103,7 +103,7 @@
                   color: 'gray.800',
                   backgroundColor: 'gray.100',
                 })}
-                href={`/tag/${tag.name}`}
+                href={`/tag/${tag.name}/post`}
               >
                 #{tag.name}
               </a>

--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -808,7 +808,7 @@
                   {#each $query.post.tags as { tag, kind } (tag.id)}
                     {#if kind === 'TITLE'}
                       <dd class={css({ fontSize: '13px', color: 'gray.400', textDecorationLine: 'underline' })}>
-                        <a href={`/tag/${tag.name}`}>#{tag.name}</a>
+                        <a href={`/tag/${tag.name}/post`}>#{tag.name}</a>
                       </dd>
                     {/if}
                   {/each}
@@ -841,7 +841,7 @@
                   {#each $query.post.tags as { tag, kind } (tag.id)}
                     {#if kind === 'CHARACTER'}
                       <dd class={css({ fontSize: '13px', color: 'gray.400', textDecorationLine: 'underline' })}>
-                        <a href={`/tag/${tag.name}`}>#{tag.name}</a>
+                        <a href={`/tag/${tag.name}/post`}>#{tag.name}</a>
                       </dd>
                     {/if}
                   {/each}
@@ -874,7 +874,7 @@
                   {#each $query.post.tags as { tag, kind } (tag.id)}
                     {#if kind === 'COUPLING'}
                       <dd class={css({ fontSize: '13px', color: 'gray.400', textDecorationLine: 'underline' })}>
-                        <a href={`/tag/${tag.name}`}>#{tag.name}</a>
+                        <a href={`/tag/${tag.name}/post`}>#{tag.name}</a>
                       </dd>
                     {/if}
                   {/each}
@@ -907,7 +907,7 @@
                   {#each $query.post.tags as { tag, kind } (tag.id)}
                     {#if kind === 'TRIGGER'}
                       <dd class={css({ fontSize: '13px', color: 'gray.400', textDecorationLine: 'underline' })}>
-                        <a href={`/tag/${tag.name}`}>#{tag.name}</a>
+                        <a href={`/tag/${tag.name}/post`}>#{tag.name}</a>
                       </dd>
                     {/if}
                   {/each}
@@ -940,7 +940,7 @@
                   {#each $query.post.tags as { tag, kind } (tag.id)}
                     {#if kind === 'EXTRA'}
                       <dd class={css({ fontSize: '13px', color: 'gray.400', textDecorationLine: 'underline' })}>
-                        <a href={`/tag/${tag.name}`}>#{tag.name}</a>
+                        <a href={`/tag/${tag.name}/post`}>#{tag.name}</a>
                       </dd>
                     {/if}
                   {/each}

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/PostItem.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/PostItem.svelte
@@ -120,7 +120,7 @@
   {#if $post.tags}
     <div class={flex({ wrap: 'wrap', gap: '6px', marginTop: '8px' })}>
       {#each $post.tags.slice(0, 4) as { tag } (tag.id)}
-        <Tag href={`/tag/${tag.name}`} size="sm">#{tag.name}</Tag>
+        <Tag href={`/tag/${tag.name}/post`} size="sm">#{tag.name}</Tag>
       {/each}
       {#if $post.tags.length > 4}
         <Tag size="sm">+{$post.tags.length - 4}개의 태그</Tag>

--- a/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
@@ -269,7 +269,7 @@
     {:else}
       <div class={flex({ flexWrap: 'wrap', gap: '12px' })}>
         {#each $query.searchTags.slice(0, 6) as tag (tag.id)}
-          <Tag href={`/tag/${tag.name}`} size="lg">#{tag.name}</Tag>
+          <Tag href={`/tag/${tag.name}/post`} size="lg">#{tag.name}</Tag>
         {/each}
       </div>
     {/if}

--- a/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
@@ -58,7 +58,7 @@
 {:else}
   <div class={flex({ flexWrap: 'wrap', gap: '12px', smDown: { paddingX: '16px' } })}>
     {#each $query.searchTags as tag (tag.id)}
-      <Tag href={`/tag/${tag.name}`} size="lg">#{tag.name}</Tag>
+      <Tag href={`/tag/${tag.name}/post`} size="lg">#{tag.name}</Tag>
     {/each}
   </div>
 {/if}

--- a/apps/penxle.com/src/routes/(default)/tag/[name]/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/tag/[name]/+layout.svelte
@@ -171,8 +171,8 @@
     })}
   >
     <TabHead style={css.raw({ width: 'full' })} variant="secondary">
-      <TabHeadItem id={1} pathname={`/tag/${$page.params.name}`}>위키</TabHeadItem>
       <TabHeadItem id={2} pathname={`/tag/${$page.params.name}/post`}>포스트</TabHeadItem>
+      <TabHeadItem id={1} pathname={`/tag/${$page.params.name}`}>위키</TabHeadItem>
       <!-- <TabHeadItem id={3}>스페이스</TabHeadItem> -->
     </TabHead>
 


### PR DESCRIPTION
현재 위키 페이지가 미구현상태이므로 태그 상세 페이지에서 포스트 목록을 먼저 표시하도록 수정