### PR TITLE
링크 타입 버튼에 _enabled 내부 스타일 값이 무시되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/styles/conditions.ts
+++ b/apps/penxle.com/src/styles/conditions.ts
@@ -1,4 +1,5 @@
 export const conditions = {
   invalid: '&:is(:invalid, [data-invalid], [aria-invalid="true"])',
   active: '&:is(:active:active, [data-active])',
+  enabled: '&:is(:enabled, a)',
 };


### PR DESCRIPTION
링크는 `:enabled` 상태가 없어 발생하는 문제로 a 엘리먼트의 경우 bypass 하도록 선택자를 덮어씌워서 해결했습니다.