### PR TITLE
에디터 툴바 리뉴얼

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
@@ -316,7 +316,7 @@
       align: 'center',
       borderBottomWidth: '1px',
       borderBottomColor: 'gray.200',
-      paddingX: '24px',
+      paddingX: '20px',
       height: '56px',
       hideBelow: 'sm',
     })}
@@ -324,14 +324,14 @@
     <div class={flex({ align: 'center', pointerEvents: 'auto' })}>
       <div
         class={center({
-          gap: '12px',
+          gap: '10px',
           height: '34px',
           _after: {
             content: '""',
             borderRightWidth: '1px',
             borderRightColor: 'gray.300',
-            marginRight: '12px',
-            height: '16px',
+            marginX: '8px',
+            height: '12px',
           },
         })}
       >
@@ -339,7 +339,7 @@
           <button
             class={flex({
               align: 'center',
-              gap: '4px',
+              gap: '10px',
               borderRadius: '4px',
               paddingLeft: '4px',
               paddingRight: '2px',
@@ -396,7 +396,7 @@
               class={flex({
                 justify: 'space-between',
                 align: 'center',
-                gap: '4px',
+                gap: '10px',
                 borderRadius: '4px',
                 paddingLeft: '4px',
                 paddingRight: '2px',
@@ -461,7 +461,7 @@
               class={flex({
                 justify: 'space-between',
                 align: 'center',
-                gap: '4px',
+                gap: '10px',
                 borderRadius: '4px',
                 paddingLeft: '4px',
                 paddingRight: '2px',
@@ -513,14 +513,13 @@
 
       <div
         class={center({
-          gap: '4px',
+          gap: '10px',
           _after: {
             content: '""',
             borderRightWidth: '1px',
             borderRightColor: 'gray.300',
-            marginLeft: '8px',
-            marginRight: '12px',
-            height: '16px',
+            marginX: '8px',
+            height: '12px',
           },
         })}
       >
@@ -591,9 +590,8 @@
             content: '""',
             borderRightWidth: '1px',
             borderRightColor: 'gray.300',
-            marginLeft: '8px',
-            marginRight: '12px',
-            height: '16px',
+            marginX: '8px',
+            height: '12px',
           },
         })}
       >
@@ -714,14 +712,13 @@
 
       <div
         class={center({
-          gap: '4px',
+          gap: '10px',
           _after: {
             content: '""',
             borderRightWidth: '1px',
             borderRightColor: 'gray.300',
-            marginLeft: '8px',
-            marginRight: '12px',
-            height: '16px',
+            marginX: '8px',
+            height: '12px',
           },
         })}
       >
@@ -833,14 +830,13 @@
 
       <div
         class={center({
-          gap: '4px',
+          gap: '12px',
           _after: {
             content: '""',
             borderRightWidth: '1px',
             borderRightColor: 'gray.300',
-            marginLeft: '8px',
-            marginRight: '12px',
-            height: '16px',
+            marginX: '8px',
+            height: '12px',
           },
         })}
       >


### PR DESCRIPTION
## 고치기

#1595 이후 생겨난 문제로 팝오버 컨테이너 너비가 필요 이상으로 늘어져 보여주는 문제가 있습니다. 이번 리뉴얼 수정에 같이 해결이 필요합니다. 

해당 문제를 스테이징 서버 (https://staging.withglyph.com/) 에서 확인 가능합니다.

<img width="243" alt="스크린샷 2024-03-29 오전 12 44 52" src="https://github.com/withglyph/glyph/assets/5278201/3e052cb1-65e5-41ab-a7df-58d6ccb88fb9">
<img width="199" alt="스크린샷 2024-03-29 오전 12 44 56" src="https://github.com/withglyph/glyph/assets/5278201/e0e8c59c-739d-47a2-9627-b1b1963a077d">


