### PR TITLE
sm 뷰포트에서 검색 아이콘 버튼 클릭하면 검색 입력에 자동으로 초점 맞추기

### DIFF
--- a/apps/penxle.com/src/lib/components/v2/forms/TextInput.svelte
+++ b/apps/penxle.com/src/lib/components/v2/forms/TextInput.svelte
@@ -9,9 +9,10 @@
   export let value: HTMLInputAttributes['value'] = undefined;
   export let style: SystemStyleObject | undefined = undefined;
   export let size: Variants['size'] = 'md';
+  export let inputEl: HTMLInputElement | undefined = undefined;
 
   type $$Props = RecipeVariantProps<typeof recipe> &
-    Omit<HTMLInputAttributes, 'class' | 'style' | 'size'> & { style?: SystemStyleObject };
+    Omit<HTMLInputAttributes, 'class' | 'style' | 'size'> & { style?: SystemStyleObject; inputEl?: HTMLInputElement };
   type $$Events = {
     input: Event & { currentTarget: HTMLInputElement };
     keydown: KeyboardEvent & { currentTarget: HTMLInputElement };
@@ -100,6 +101,7 @@
     </div>
   {/if}
   <input
+    bind:this={inputEl}
     id={name}
     {name}
     class={cx(

--- a/apps/penxle.com/src/routes/(default)/SearchBar.svelte
+++ b/apps/penxle.com/src/routes/(default)/SearchBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import qs from 'query-string';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import IconSearch from '~icons/effit/search';
   import IconChevronLeft from '~icons/tabler/chevron-left';
   import IconX from '~icons/tabler/x';
@@ -14,6 +14,7 @@
 
   export let style: SystemStyleObject | undefined = undefined;
 
+  let inputEl: HTMLInputElement | undefined;
   let value = ($page.url.pathname === '/search' && $page.url.searchParams.get('q')) || '';
 
   export let open = false;
@@ -81,7 +82,7 @@
         await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
       }}
     >
-      <TextInput placeholder="검색어를 입력하세요" size="sm" type="search" bind:value>
+      <TextInput placeholder="검색어를 입력하세요" size="sm" type="search" bind:inputEl bind:value>
         <button slot="left-icon" class={center({ transition: 'common', color: 'gray.500' })} type="submit">
           <Icon icon={IconSearch} size={20} />
         </button>
@@ -104,6 +105,8 @@
     type="button"
     on:click={async () => {
       open = true;
+      await tick();
+      inputEl?.focus();
     }}
   >
     <Icon style={css.raw({ color: 'gray.900' })} icon={IconSearch} size={24} />


### PR DESCRIPTION
아이콘 버튼을 클릭해야 검색 입력이 보여지는 경험인데,
검색 입력 UI를 한번 더 클릭해야 초점이 맞추어 지는게 불필요한 단계라고
느껴져서 자동 초점을 설정하는 코드를 추가했습니다.