### PR TITLE
정렬 서식 메뉴 내 아이템 버튼에 패딩이 없어서 수정함

### DIFF
--- a/apps/penxle.com/src/lib/components/menu/MenuItem.svelte
+++ b/apps/penxle.com/src/lib/components/menu/MenuItem.svelte
@@ -1,6 +1,7 @@
 <script generics="T extends 'button' | 'div' | 'link' = 'button'" lang="ts">
   import { getContext } from 'svelte';
   import { css } from '$styled-system/css';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
   import type { SystemStyleObject } from '$styled-system/types';
 
   type $$Props = {
@@ -8,7 +9,7 @@
     style?: SystemStyleObject;
     disabled?: boolean;
   } & (T extends 'link' ? { href: string; external?: boolean } : unknown) &
-    (T extends 'button' ? { 'aria-pressed'?: boolean } : unknown);
+    (T extends 'button' ? Omit<HTMLButtonAttributes, 'type' | 'style' | 'disabled'> : unknown);
 
   type $$Events = T extends 'link' ? unknown : { click: MouseEvent };
 
@@ -54,6 +55,7 @@
     rel: 'noopener noreferrer',
   }}
   {...props}
+  {...$$restProps}
 >
   <slot />
 </svelte:element>

--- a/apps/penxle.com/src/lib/tiptap/values.ts
+++ b/apps/penxle.com/src/lib/tiptap/values.ts
@@ -2,6 +2,8 @@ import IconAlignJustify from '~icons/effit/align-justify';
 import IconAlignCenter from '~icons/tabler/align-center';
 import IconAlignLeft from '~icons/tabler/align-left';
 import IconAlignRight from '~icons/tabler/align-right';
+import IconList from '~icons/tabler/list';
+import IconListNumbers from '~icons/tabler/list-numbers';
 
 export const values = {
   defaultColor: '#09090B',
@@ -57,6 +59,19 @@ export const values = {
     { label: '중앙', value: 'center', icon: IconAlignCenter },
     { label: '오른쪽', value: 'right', icon: IconAlignRight },
     { label: '양쪽', value: 'justify', icon: IconAlignJustify },
+  ],
+
+  list: [
+    {
+      label: '순서 없는 목록',
+      value: 'bullet_list',
+      icon: IconList,
+    },
+    {
+      label: '순서 있는 목록',
+      value: 'ordered_list',
+      icon: IconListNumbers,
+    },
   ],
 
   horizontalRule: [

--- a/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
@@ -13,8 +13,6 @@
   import IconHtml from '~icons/tabler/html';
   import IconItalic from '~icons/tabler/italic';
   import IconLink from '~icons/tabler/link';
-  import IconList from '~icons/tabler/list';
-  import IconListNumbers from '~icons/tabler/list-numbers';
   import IconMinus from '~icons/tabler/minus';
   import IconPhoto from '~icons/tabler/photo';
   import IconQuote from '~icons/tabler/quote';
@@ -623,18 +621,14 @@
             </button>
 
             {#each values.textAlign as textAlign (textAlign.value)}
-              <button
-                class={center({
-                  size: '34px',
-                  _hover: { backgroundColor: 'gray.50' },
-                  _pressed: { color: 'teal.500' },
-                })}
+              <MenuItem
+                style={css.raw({ _pressed: { color: 'teal.500' } })}
+                aria-label={textAlign.label}
                 aria-pressed={editor?.isActive({ textAlign: textAlign.value })}
-                type="button"
                 on:click={() => editor?.chain().focus().setParagraphTextAlign(textAlign.value).run()}
               >
                 <Icon icon={textAlign.icon} size={24} />
-              </button>
+              </MenuItem>
             {/each}
           </Menu>
         </ToolbarButtonTooltip>
@@ -748,24 +742,23 @@
               type="button"
               let:open
             >
-              <Icon icon={IconList} size={24} />
+              <Icon
+                icon={editor?.isActive(values.list[1].value) ? values.list[1].icon : values.list[0].icon}
+                size={24}
+              />
             </button>
-
-            <MenuItem
-              on:click={() => {
-                editor?.chain().focus().toggleBulletList().run();
-              }}
-            >
-              <Icon icon={IconList} size={24} />
-            </MenuItem>
-
-            <MenuItem
-              on:click={() => {
-                editor?.chain().focus().toggleOrderedList().run();
-              }}
-            >
-              <Icon icon={IconListNumbers} size={24} />
-            </MenuItem>
+            {#each values.list as list (list.value)}
+              <MenuItem
+                style={css.raw({ _pressed: { color: 'teal.500' } })}
+                aria-label={list.label}
+                aria-pressed={editor?.isActive(list.value)}
+                on:click={() => {
+                  editor?.chain().focus().toggleList(list.value, 'list_item').run();
+                }}
+              >
+                <Icon icon={list.icon} size={24} />
+              </MenuItem>
+            {/each}
           </Menu>
         </ToolbarButtonTooltip>
 


### PR DESCRIPTION
MenuItem 컴포넌트를 사용하지 않고 있어서 사용하도록 수정했습니다.

## 추가 관련 수정사항

- 목록 서식 메뉴도 현재 선택한 항목을 하이라이팅하기
- 아이콘만 보여주는 메뉴 아이템에 aria-label 명시하기