### PR TITLE
TextInput 타입 오류 수정

### DIFF
--- a/apps/penxle.com/src/lib/components/v2/forms/TextInput.svelte
+++ b/apps/penxle.com/src/lib/components/v2/forms/TextInput.svelte
@@ -11,7 +11,7 @@
   export let size: Variants['size'] = 'md';
 
   type $$Props = RecipeVariantProps<typeof recipe> &
-    Omit<HTMLInputAttributes, 'class' | 'style'> & { style?: SystemStyleObject };
+    Omit<HTMLInputAttributes, 'class' | 'style' | 'size'> & { style?: SystemStyleObject };
   type $$Events = {
     input: Event & { currentTarget: HTMLInputElement };
     keydown: KeyboardEvent & { currentTarget: HTMLInputElement };


### PR DESCRIPTION
v2 `TextInput` 컴포넌트의 타입 중 `size` 가 input 자체의 `size` 프로퍼티와 충돌하는 문제가 있어 해당 타입을 제외하도록 수정했습니다.
