### PR TITLE
검색 바 컨테이너 내부 입력 요소 너비에 flex-grow 설정하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/SearchBar.svelte
+++ b/apps/penxle.com/src/routes/(default)/SearchBar.svelte
@@ -78,6 +78,7 @@
       <Icon icon={IconChevronLeft} size={24} />
     </button>
     <form
+      class={css({ flexGrow: '1' })}
       on:submit|preventDefault={async () => {
         await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
       }}


### PR DESCRIPTION
sm 이하 너비에서 검색 바 입력 요소가 전체를 차지하지 않고 있어
수정했습니다.

헤더 리뉴얼 작업 #1621 의 후속 작업입니다.