### PR TITLE
Menu 컴포넌트 백드롭 영역의 z-index 가 다른 UI와 충돌이 되어서 제거함

### DIFF
--- a/apps/penxle.com/src/lib/components/menu/Menu.svelte
+++ b/apps/penxle.com/src/lib/components/menu/Menu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { setContext } from 'svelte';
   import { afterNavigate } from '$app/navigation';
-  import { createFloatingActions, portal } from '$lib/svelte/actions';
+  import { createFloatingActions } from '$lib/svelte/actions';
   import { css } from '$styled-system/css';
   import type { Placement } from '@floating-ui/dom';
   import type { SystemStyleObject } from '$styled-system/types';
@@ -57,12 +57,11 @@
 
 {#if open}
   <div
-    class={css({ position: 'fixed', inset: '0', zIndex: '40' })}
+    class={css({ position: 'fixed', inset: '0' })}
     role="button"
     tabindex="-1"
     on:click={() => (open = false)}
     on:keypress={null}
-    use:portal
   />
 
   <div


### PR DESCRIPTION
![CleanShot 2024-04-02 at 18.25.32@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8hvfTZ24DHo9E1Ato9YP/d51230ae-a1ad-43d6-a5cd-db396a08771c.png)

Modal 컴포넌트의 z-index가 `50`인데 Menu 컴포넌트 백드롭 영역의 z-index 가 `40`이라서 두가지 문제가 있었습니다.

1. 열어둔 메뉴가 닫히지 않음
2. 새 메뉴 요소가 의도하지 않은 위치에 자리잡힘