### PR TITLE
sm 이하 뷰포트에서 이미지 가로 너비 전체 차지하기

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/image/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/image/Component.svelte
@@ -64,7 +64,7 @@
   });
 </script>
 
-<NodeView style={center.raw({ paddingY: '4px' })} data-drag-handle draggable>
+<NodeView style={center.raw({ paddingY: '4px', smDown: { marginX: '-20px' } })} data-drag-handle draggable>
   {#if editor?.isEditable}
     <div
       class={css(


### PR DESCRIPTION
## 적용 대상 범위

- 포스트 본문 내 이미지 요소
- 에디터 본문 내 이미지 요소 - 본문에 보이는 그대로 편집 화면을 보여주도록 하기 위해 본문이든 에디터 환경이든 신경쓰지 않도록 했습니다.