### PR TITLE
ColorPicker 구현체 재설계 및 기능 개선하기

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
@@ -372,9 +372,10 @@
             />
           {/if}
 
-          <div class={css({ zIndex: '50' }, !colorPickerOpen && { display: 'none' })} use:colorPickerFloating>
+          <div class={css({ zIndex: '50' })} use:colorPickerFloating>
             <ColorPicker
               hex={currentColor}
+              open={colorPickerOpen}
               on:input={(event) => {
                 const { hex } = event.detail;
                 if (hex === values.defaultColor) {


### PR DESCRIPTION
코드 결합도가 높아서 Hue 값 변경 시 그라데이션 박스 위치 유지하는 기능을 지원하기 쉽지 않았는데, 컴포넌트 재설계를 통해 기능 지원을 이루었고 검수 중에 있습니다.

<h2>기능 개선 항목</h2>

- Hue 슬라이더 입력 값 변경 시 그라데이션 박스 위치 유지하기
- 외부에서 색상 업데이트 시(선택한 텍스트가 변경 된 경우 등) Hue 슬라이더 입력 값 초기화하기
- Hue 슬라이더 `0` ~ `360` 값까지 지원하기. 이전에는 `300` 까지만 지원했었음

<h2>컴포넌트 재설계 핵심</h2>

- 현재 색상 정보를 완전히 단방향으로 다루게 정리함

<h2>기타 사항</h2>

- [x] 박스 그라데이션 좌표 제어가 기대하는 위치와 다르게 되는 문제가 있어서 우선 Draft 로 올려둡니다.