### PR TITLE
eslint no-empty-file 룰 삭제

### DIFF
--- a/apps/penxle.com/src/routes/(auth)/+layout.ts
+++ b/apps/penxle.com/src/routes/(auth)/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(auth)/login/+page.ts
+++ b/apps/penxle.com/src/routes/(auth)/login/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/(index)/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/(index)/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/(index)/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/(index)/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/(index)/feed/subscribes/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/(index)/feed/subscribes/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/me/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/(index)/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/(index)/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/bookmark/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/bookmark/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/purchased/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/purchased/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/recent/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/recent/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/notifications/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/notifications/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/posts/(index)/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/posts/(index)/+page.ts
@@ -1,1 +1,0 @@
-/* eslint-disable unicorn/no-empty-file */

--- a/apps/penxle.com/src/routes/(default)/me/posts/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/me/posts/+layout.ts
@@ -1,1 +1,0 @@
-/* eslint-disable unicorn/no-empty-file */

--- a/apps/penxle.com/src/routes/(default)/me/revenue/+layout.ts
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/revenue/settlement/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/settlement/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/settings/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/settings/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/settings/deactivate/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/settings/deactivate/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/me/settings/notifications/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/me/settings/notifications/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/point/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/point/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/(default)/point/purchase/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/point/purchase/+page.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/apps/penxle.com/src/routes/+layout.ts
+++ b/apps/penxle.com/src/routes/+layout.ts
@@ -1,1 +1,0 @@
-// eslint-disable-next-line unicorn/no-empty-file

--- a/packages/lintconfig/eslint.js
+++ b/packages/lintconfig/eslint.js
@@ -72,6 +72,7 @@ export default [
       'svelte/sort-attributes': 'error',
       'unicorn/catch-error-name': ['error', { name: 'err' }],
       'unicorn/consistent-function-scoping': 'off',
+      'unicorn/no-empty-file': 'off',
       'unicorn/no-null': 'off',
       'unicorn/no-useless-undefined': 'off',
       'unicorn/prefer-ternary': ['error', 'only-single-line'],


### PR DESCRIPTION
불필요한 코드 반복을 막기 위해 eslint의 `unicorn/no-empty-file` 규칙을 제거함
