### PR TITLE
잘못 들어간 fetchExchange 임포트 구문 수정

### DIFF
--- a/packages/glitch/src/client/index.ts
+++ b/packages/glitch/src/client/index.ts
@@ -1,6 +1,7 @@
-import { Client, fetchExchange } from '@urql/core';
+import { Client } from '@urql/core';
 import { devtoolsExchange } from '@urql/devtools';
 import { cacheExchange } from '@urql/exchange-graphcache';
+import { fetchExchange } from './exchanges/fetch';
 import type { Exchange } from '@urql/core';
 import type { CacheExchangeOpts } from '@urql/exchange-graphcache';
 import type { GlitchClient } from '../types';


### PR DESCRIPTION
urql의 fetchExchange가 아닌 커스텀 fetchExchange를 썼어야 했는데 임포트를 잘못 함
