### PR TITLE
폰트 subpixel antialiasing 비활성화

### DIFF
--- a/apps/penxle.com/src/styles/global.ts
+++ b/apps/penxle.com/src/styles/global.ts
@@ -19,8 +19,8 @@ export const globalCss = defineGlobalStyles({
     fontFamily: 'ui',
     textSizeAdjust: '100%',
 
-    WebkitFontSmoothing: 'auto',
-    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'grayscale',
 
     color: 'gray.900',
     lineHeight: '1.44',


### PR DESCRIPTION
macOS에서 윈도우와 같은 폰트 렌더링을 위해 subpixel antialiasing을 비활성화함
