### PR TITLE
drizzle pg-core jsonb 버그 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/database/schemas/tables.ts
+++ b/apps/penxle.com/src/lib/server/database/schemas/tables.ts
@@ -1,8 +1,8 @@
 import { init } from '@paralleldrive/cuid2';
 import { sql } from 'drizzle-orm';
-import { boolean, index, integer, jsonb, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
+import { boolean, index, integer, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
 import * as E from './enums';
-import { datetime } from './types';
+import { datetime, jsonb } from './types';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 const createId = init({ length: 16 });

--- a/apps/penxle.com/src/lib/server/database/schemas/types.ts
+++ b/apps/penxle.com/src/lib/server/database/schemas/types.ts
@@ -6,3 +6,9 @@ export const datetime = customType<{ data: dayjs.Dayjs; driverData: string }>({
   fromDriver: (value) => dayjs(value),
   toDriver: (value) => value.toISOString(),
 });
+
+export const jsonb = customType<{ data: unknown }>({
+  dataType: () => 'jsonb',
+  toDriver: (value) => value,
+  fromDriver: (value) => (typeof value === 'string' ? JSON.parse(value) : value),
+});


### PR DESCRIPTION
drizzle이 postgres.js를 이용해서 jsonb 컬럼을 저장할 때 전체 데이터를 stringify해서 저장하는 이슈가 있어 커스텀 타입 생성으로 workaround함
