### PR TITLE
drizzle orm에서 빈 array에 inArray 시도하는 경우 강제로 조건 폴백하도록 별도 유틸리티 함수 추가

### DIFF
--- a/apps/penxle.com/scripts/202402-event-reward.ts
+++ b/apps/penxle.com/scripts/202402-event-reward.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
-import { database, PointBalances, PointTransactions, UserEventEnrollments } from '$lib/server/database';
+import { and, eq, isNull } from 'drizzle-orm';
+import { database, inArray, PointBalances, PointTransactions, UserEventEnrollments } from '$lib/server/database';
 
 let eventEnrollmentCount = 0;
 do {

--- a/apps/penxle.com/src/lib/server/database/index.ts
+++ b/apps/penxle.com/src/lib/server/database/index.ts
@@ -13,3 +13,4 @@ export type Database = typeof database;
 export type Transaction = Database extends PgDatabase<infer T, infer U, infer V> ? PgTransaction<T, U, V> : never;
 
 export * from './schemas/tables';
+export * from './utils';

--- a/apps/penxle.com/src/lib/server/database/utils.ts
+++ b/apps/penxle.com/src/lib/server/database/utils.ts
@@ -1,0 +1,36 @@
+import { inArray as inArray_, notInArray as notInArray_, sql } from 'drizzle-orm';
+import type { Column, GetColumnData, Placeholder, SQL, SQLWrapper } from 'drizzle-orm';
+
+export function inArray<T>(column: SQL.Aliased<T>, values: (T | Placeholder)[] | SQLWrapper): SQL;
+export function inArray<TColumn extends Column>(
+  column: TColumn,
+  values: (GetColumnData<TColumn, 'raw'> | Placeholder)[] | SQLWrapper,
+): SQL;
+export function inArray<T extends SQLWrapper>(
+  column: Exclude<T, SQL.Aliased | Column>,
+  values: (unknown | Placeholder)[] | SQLWrapper,
+): SQL;
+export function inArray(column: SQLWrapper, values: (unknown | Placeholder)[] | SQLWrapper): SQL {
+  if (Array.isArray(values) && values.length === 0) {
+    return sql`1 = 0`;
+  }
+
+  return inArray_(column, values);
+}
+
+export function notInArray<T>(column: SQL.Aliased<T>, values: (T | Placeholder)[] | SQLWrapper): SQL;
+export function notInArray<TColumn extends Column>(
+  column: TColumn,
+  values: (GetColumnData<TColumn, 'raw'> | Placeholder)[] | SQLWrapper,
+): SQL;
+export function notInArray<T extends SQLWrapper>(
+  column: Exclude<T, SQL.Aliased | Column>,
+  values: (unknown | Placeholder)[] | SQLWrapper,
+): SQL;
+export function notInArray(column: SQLWrapper, values: (unknown | Placeholder)[] | SQLWrapper): SQL {
+  if (Array.isArray(values) && values.length === 0) {
+    return sql`1 = 1`;
+  }
+
+  return notInArray_(column, values);
+}

--- a/apps/penxle.com/src/lib/server/graphql/schemas/collection.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/collection.ts
@@ -1,6 +1,6 @@
-import { and, asc, count, eq, inArray, or } from 'drizzle-orm';
+import { and, asc, count, eq, or } from 'drizzle-orm';
 import { NotFoundError, PermissionDeniedError } from '$lib/errors';
-import { database, Posts, SpaceCollectionPosts, SpaceCollections } from '$lib/server/database';
+import { database, inArray, Posts, SpaceCollectionPosts, SpaceCollections } from '$lib/server/database';
 import { getSpaceMember } from '$lib/server/utils';
 import { CreateSpaceCollectionSchema, UpdateSpaceCollectionSchema } from '$lib/validations';
 import { builder } from '../builder';

--- a/apps/penxle.com/src/lib/server/graphql/schemas/comment.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/comment.ts
@@ -1,9 +1,10 @@
 import dayjs from 'dayjs';
-import { and, count, eq, inArray } from 'drizzle-orm';
+import { and, count, eq } from 'drizzle-orm';
 import { PostCommentState, PostCommentVisibility } from '$lib/enums';
 import { NotFoundError, PermissionDeniedError } from '$lib/errors';
 import {
   database,
+  inArray,
   PostCommentLikes,
   PostComments,
   PostPurchases,

--- a/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
@@ -1,6 +1,15 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import * as R from 'radash';
-import { database, Posts, PostTags, PostViews, Spaces, TagFollows, UserPersonalIdentities } from '$lib/server/database';
+import {
+  database,
+  inArray,
+  Posts,
+  PostTags,
+  PostViews,
+  Spaces,
+  TagFollows,
+  UserPersonalIdentities,
+} from '$lib/server/database';
 import { elasticSearch, indexName } from '$lib/server/search';
 import {
   getMutedSpaceIds,

--- a/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
@@ -1,11 +1,11 @@
 import dayjs from 'dayjs';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { customAlphabet } from 'nanoid';
 import numeral from 'numeral';
 import { match } from 'ts-pattern';
 import { PaymentMethod, PointPurchaseState, PointTransactionCause } from '$lib/enums';
 import { NotFoundError } from '$lib/errors';
-import { database, PointPurchases, PointTransactions, PostPurchases, Users } from '$lib/server/database';
+import { database, inArray, PointPurchases, PointTransactions, PostPurchases, Users } from '$lib/server/database';
 import { exim, portone } from '$lib/server/external-api';
 import { builder } from '../builder';
 import { createObjectRef } from '../utils';

--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -1,7 +1,7 @@
 import { init as cuid } from '@paralleldrive/cuid2';
 import { hash, verify } from 'argon2';
 import dayjs from 'dayjs';
-import { and, asc, count, desc, eq, exists, gt, inArray, isNotNull, isNull, lt, ne, notExists, or } from 'drizzle-orm';
+import { and, asc, count, desc, eq, exists, gt, isNotNull, isNull, lt, ne, notExists, or } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { match, P } from 'ts-pattern';
 import { emojiData } from '$lib/emoji';
@@ -21,6 +21,7 @@ import {
   BookmarkGroupPosts,
   BookmarkGroups,
   database,
+  inArray,
   PostComments,
   PostLikes,
   PostPurchases,

--- a/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
@@ -1,10 +1,12 @@
 import dayjs from 'dayjs';
-import { and, count, desc, eq, inArray, isNotNull, ne, notExists, notInArray } from 'drizzle-orm';
+import { and, count, desc, eq, isNotNull, ne, notExists } from 'drizzle-orm';
 import { match } from 'ts-pattern';
 import { SpaceMemberRole, SpaceVisibility } from '$lib/enums';
 import { FormValidationError, IntentionalError, NotFoundError, PermissionDeniedError } from '$lib/errors';
 import {
   database,
+  inArray,
+  notInArray,
   PostRevisions,
   Posts,
   PostTags,

--- a/apps/penxle.com/src/lib/server/graphql/schemas/tag.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/tag.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, ne, notInArray } from 'drizzle-orm';
+import { and, desc, eq, ne } from 'drizzle-orm';
 import { PostTagKind } from '$lib/enums';
 import { NotFoundError } from '$lib/errors';
-import { database, PostTags, PostViews, TagFollows, Tags, UserTagMutes } from '$lib/server/database';
+import { database, notInArray, PostTags, PostViews, TagFollows, Tags, UserTagMutes } from '$lib/server/database';
 import { elasticSearch, indexName } from '$lib/server/search';
 import { getTagUsageCount, searchResultToIds } from '$lib/server/utils';
 import { builder } from '../builder';

--- a/apps/penxle.com/src/lib/server/graphql/utils.ts
+++ b/apps/penxle.com/src/lib/server/graphql/utils.ts
@@ -1,5 +1,5 @@
-import { asc, inArray } from 'drizzle-orm';
-import { database } from '../database';
+import { asc } from 'drizzle-orm';
+import { database, inArray } from '../database';
 import { builder } from './builder';
 import type { DataLoaderOptions } from '@pothos/plugin-dataloader';
 import type { AnyPgColumn, AnyPgTable, PgTable, TableConfig } from 'drizzle-orm/pg-core';

--- a/apps/penxle.com/src/lib/server/rest/routes/sso.ts
+++ b/apps/penxle.com/src/lib/server/rest/routes/sso.ts
@@ -1,11 +1,12 @@
 import dayjs from 'dayjs';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { status } from 'itty-router';
 import { nanoid } from 'nanoid';
 import qs from 'query-string';
 import * as R from 'radash';
 import {
   database,
+  inArray,
   Posts,
   ProvisionedUsers,
   SpaceMembers,

--- a/apps/penxle.com/src/lib/server/utils/notification.ts
+++ b/apps/penxle.com/src/lib/server/utils/notification.ts
@@ -1,7 +1,7 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import * as R from 'radash';
 import { UserNotificationCategory, UserNotificationMethod } from '$lib/enums';
-import { database, UserNotificationPreferences, UserNotifications } from '../database';
+import { database, inArray, UserNotificationPreferences, UserNotifications } from '../database';
 import type { Notification } from '$lib/utils';
 
 type CheckNotificationPreferencesParams = {

--- a/apps/penxle.com/src/lib/server/utils/post.ts
+++ b/apps/penxle.com/src/lib/server/utils/post.ts
@@ -1,9 +1,9 @@
 import { webcrypto } from 'node:crypto';
-import { asc, count, eq, inArray } from 'drizzle-orm';
+import { asc, count, eq } from 'drizzle-orm';
 import stringify from 'fast-json-stable-stringify';
 import * as R from 'radash';
 import { redis, useCache } from '$lib/server/cache';
-import { database, PostPurchases, PostRevisionContents, PostViews, SpaceCollectionPosts } from '../database';
+import { database, inArray, PostPurchases, PostRevisionContents, PostViews, SpaceCollectionPosts } from '../database';
 import { useFirstRow, useFirstRowOrThrow } from './database';
 import { isEmptyContent } from './tiptap';
 import type { JSONContent } from '@tiptap/core';

--- a/apps/penxle.com/src/lib/server/utils/revenue.ts
+++ b/apps/penxle.com/src/lib/server/utils/revenue.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
-import { and, eq, inArray, isNull, lt, ne, sum } from 'drizzle-orm';
+import { and, eq, isNull, lt, ne, sum } from 'drizzle-orm';
 import { match } from 'ts-pattern';
 import { RevenueWithdrawalKind } from '$lib/enums';
 import { IntentionalError } from '$lib/errors';
 import * as coocon from '$lib/server/external-api/coocon';
 import { logToSlack } from '$lib/server/utils';
 import { calculateFeeAmount, getMonthlyWithdrawableDayjsBefore } from '$lib/utils';
-import { database, Revenues, RevenueWithdrawals, UserSettlementIdentities } from '../database';
+import { database, inArray, Revenues, RevenueWithdrawals, UserSettlementIdentities } from '../database';
 
 const getWithdrawableDayjs = () => dayjs().subtract(7, 'day');
 

--- a/apps/penxle.com/src/lib/server/utils/tiptap.ts
+++ b/apps/penxle.com/src/lib/server/utils/tiptap.ts
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
-import { eq, inArray } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { traverse } from 'object-traversal';
 import { createTiptapDocument, documentToText } from '$lib/utils';
 import { useCache } from '../cache';
-import { database, Embeds, Files, Images } from '../database';
+import { database, Embeds, Files, Images, inArray } from '../database';
 import type { JSONContent } from '@tiptap/core';
 
 type RevisionContent = {


### PR DESCRIPTION
inArray 조건이 빈 배열일 경우 `1 = 0` 조건으로 변환해 오류가 발생하지 않도록 함. notInArray의 경우에도 반대로 동작하도록 수정함.
