### PR TITLE
Tooltip message keep-all 스타일로 표시하기

### DIFF
--- a/apps/penxle.com/src/lib/components/Tooltip.svelte
+++ b/apps/penxle.com/src/lib/components/Tooltip.svelte
@@ -38,6 +38,7 @@
       backgroundColor: 'gray.5',
       zIndex: '100',
       maxWidth: '230px',
+      wordBreak: 'keep-all',
     })}
     role="tooltip"
     use:floating


### PR DESCRIPTION
검수 중에 줄바꿈이 어색하게 보여서 수정했습니다.
<img width="390" alt="스크린샷 2024-04-12 오후 3 01 27" src="https://github.com/withglyph/glyph/assets/5278201/1bc83e6b-4dd4-4066-b9b7-8d160552c70d">

