### PR TITLE
모바일에서 컬렉션 추가 버튼 레이아웃이 깨지는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
@@ -65,13 +65,16 @@
     {/each}
     {#if $query.space.meAsMember}
       <li>
-        <button class={css({ textAlign: 'left' })} type="button" on:click={() => (createCollectionOpen = true)}>
+        <button
+          class={css({ textAlign: 'left', width: 'full' })}
+          type="button"
+          on:click={() => (createCollectionOpen = true)}
+        >
           <div class={css({ position: 'relative' })}>
             <div
               class={css({
-                borderWidth: '2px',
+                borderWidth: '[0.8px]',
                 borderColor: 'gray.100',
-                width: { base: '161px', sm: '206px' },
                 backgroundColor: 'gray.50',
                 aspectRatio: '3/4',
               })}


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
<img width="522" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/165ab574-5f5b-4274-93ae-caeb6ae4bd3c">|<img width="522" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/9011c7dd-6a41-4da4-9887-9cbbf31f9d1b">

** 디자인 요청으로 다른 컬렉션과 border width 맞춤