### PR TITLE
아무것도 팔로우하고 있지 않으면 구독 피드가 비도록 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
@@ -394,6 +394,10 @@ builder.queryFields((t) => ({
           .then((rows) => rows.map((row) => row.tagId)),
       ]);
 
+      if (followingSpaceIds.length === 0 && followingTagIds.length === 0) {
+        return [];
+      }
+
       const searchResult = await elasticSearch.search({
         index: indexName('posts'),
         query: {


### PR DESCRIPTION
팔로우 ID 목록이 모두 비어있으면 ES 쿼리가 비어서 모든 글이 리턴되는듯