### PR TITLE
팁탭 Paragraph 노드 스타일 유지 코드 임시 비활성화

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
@@ -1,5 +1,4 @@
-import { findChildren, Node } from '@tiptap/core';
-import { Plugin } from '@tiptap/pm/state';
+import { Node } from '@tiptap/core';
 import { values } from '$lib/tiptap/values';
 import { closest } from '$lib/utils';
 
@@ -119,35 +118,35 @@ export const Paragraph = Node.create({
     };
   },
 
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        appendTransaction: (_, __, newState) => {
-          const { doc, selection, storedMarks, tr } = newState;
-          const { $from, empty } = selection;
+  // addProseMirrorPlugins() {
+  //   return [
+  //     new Plugin({
+  //       appendTransaction: (_, __, newState) => {
+  //         const { doc, selection, storedMarks, tr } = newState;
+  //         const { $from, empty } = selection;
 
-          if (
-            $from.parent.type.name !== this.name ||
-            !empty ||
-            $from.parentOffset !== 0 ||
-            $from.parent.childCount !== 0 ||
-            storedMarks?.length
-          ) {
-            return;
-          }
+  //         if (
+  //           $from.parent.type.name !== this.name ||
+  //           !empty ||
+  //           $from.parentOffset !== 0 ||
+  //           $from.parent.childCount !== 0 ||
+  //           storedMarks?.length
+  //         ) {
+  //           return;
+  //         }
 
-          const lastNode = findChildren(doc, (node) => node.type.name === this.name).findLast(
-            ({ node, pos }) => node.childCount > 0 && pos < $from.pos,
-          );
+  //         const lastNode = findChildren(doc, (node) => node.type.name === this.name).findLast(
+  //           ({ node, pos }) => node.childCount > 0 && pos < $from.pos,
+  //         );
 
-          const lastChild = lastNode?.node.lastChild;
-          if (!lastChild) {
-            return;
-          }
+  //         const lastChild = lastNode?.node.lastChild;
+  //         if (!lastChild) {
+  //           return;
+  //         }
 
-          return tr.setStoredMarks(lastChild.marks);
-        },
-      }),
-    ];
-  },
+  //         return tr.setStoredMarks(lastChild.marks);
+  //       },
+  //     }),
+  //   ];
+  // },
 });


### PR DESCRIPTION
문단 첫 글자가 깨져서 입력되는 문제가 생겨서 일단 임시로 비활성화함

비활성화함으로서 생기는 문제: 엔터 두 번 입력시 기존 마크가 유지되지 않음
