### PR TITLE
일부 상황에서 포인트 결제 실패하는 문제 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
@@ -110,7 +110,7 @@ builder.mutationFields((t) => ({
     args: { input: t.arg({ type: PurchasePointInput }) },
     resolve: async (_, { input }, context) => {
       const paymentKey = `PX${input.pointAmount}${customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ')(8)}`;
-      const paymentAmount = input.pointAmount * 1.1;
+      const paymentAmount = Math.floor(input.pointAmount * 1.1);
       const expiresAt = dayjs().add(1, 'hour');
 
       const pgData = await match(input.paymentMethod)


### PR DESCRIPTION
부동소수점 문제로 db에 1000이 아닌 1000.000000001 등을 넣으려고 해 postgres.js에서 오류가 발생하는 문제 해결함
