### PR TITLE
포스트 뷰 컬렉션 이름, 텍스트 인풋 폰트 사이즈 수정

### DIFF
--- a/apps/website/src/routes/(default)/[space]/PostView.svelte
+++ b/apps/website/src/routes/(default)/[space]/PostView.svelte
@@ -136,7 +136,6 @@
               id
               title
               subtitle
-              previewText
               price
             }
 
@@ -285,7 +284,6 @@
         subtitle
         content
         createdAt
-        previewText
         paragraphIndent
         paragraphSpacing
       }
@@ -445,6 +443,7 @@
           align: 'center',
           gap: '2px',
           marginBottom: { base: '12px', sm: '24px' },
+          fontSize: { base: '14px', sm: '16px' },
           color: 'gray.500',
           width: 'fit',
         })}
@@ -1048,7 +1047,12 @@
             }
           }}
         >
-          <TextInput placeholder="비밀번호를 입력해주세요" type="password" bind:value={password} />
+          <TextInput
+            style={css.raw({ fontSize: '14px!' })}
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+            bind:value={password}
+          />
           <Button style={css.raw({ width: '68px' })} size="sm" type="submit">입력</Button>
         </form>
       </AlertText>


### PR DESCRIPTION
- 컬렉션 이름 폰트 사이즈 변경

|수정 전|수정 후|
|--|--|
<img width="373" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/c55af028-778a-4933-9c02-462bed140de4">|<img width="378" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/6955c037-c6df-46e0-bf1e-a17d9e102b90">

- 비밀번호 입력 텍스트인풋 폰트 사이즈 변경

|수정 전|수정 후|
|--|--|
<img width="403" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/a2b7f259-4c76-4dd7-899f-b2ca6de5350d">|<img width="359" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/5b08ee8a-54b8-42bb-a7e1-a28b372b1896">
