### PR TITLE
컬렉션 관리 관련 워딩 및 플로우 수정

### DIFF
--- a/apps/website/src/lib/components/Alert.svelte
+++ b/apps/website/src/lib/components/Alert.svelte
@@ -5,6 +5,7 @@
   import type { SystemStyleObject } from '$styled-system/types';
 
   export let open: boolean;
+  export let containerStyle: SystemStyleObject | undefined = undefined;
   export let actionStyle: SystemStyleObject | undefined = undefined;
 </script>
 
@@ -34,16 +35,19 @@
       })}
     >
       <div
-        class={css({
-          position: 'relative',
-          display: 'flex',
-          flexDirection: 'column',
-          width: 'full',
-          maxWidth: { base: '311px', sm: '420px' },
-          backgroundColor: 'gray.5',
-          pointerEvents: 'auto',
-          userSelect: 'text',
-        })}
+        class={css(
+          {
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            width: 'full',
+            maxWidth: { base: '311px', sm: '420px' },
+            backgroundColor: 'gray.5',
+            pointerEvents: 'auto',
+            userSelect: 'text',
+          },
+          containerStyle,
+        )}
         use:scrollLock
         in:fly={{ y: 10 }}
         out:fade={{ duration: 150 }}

--- a/apps/website/src/lib/components/pages/collections/ManageCollectionModal.svelte
+++ b/apps/website/src/lib/components/pages/collections/ManageCollectionModal.svelte
@@ -196,7 +196,7 @@
 
   <svelte:fragment slot="title">
     <p class={flex({ align: 'center', gap: '4px' })}>
-      {page === 'registerPosts' ? '포스트 관리' : '순서 변경'}<Tooltip
+      {page === 'registerPosts' ? '컬렉션 관리' : '순서 변경'}<Tooltip
         message={page === 'registerPosts'
           ? '한 포스트는 하나의 컬렉션에만 포함될 수 있어요'
           : '박스를 드래그해서 놓으면 순서를 변경할 수 있어요'}
@@ -270,7 +270,7 @@
 
             <div class={flex({ direction: 'column', gap: '14px', flexGrow: '1', truncate: true })}>
               <div class={css({ truncate: true })}>
-                <p class={css({ fontSize: '14px', fontWeight: 'semibold', truncate: true })}>
+                <p class={css({ fontSize: '14px', fontWeight: 'medium', truncate: true })}>
                   {post.publishedRevision?.title ?? '(제목 없음)'}
                 </p>
                 <p class={css({ marginTop: '2px', fontSize: '13px', color: 'gray.600', height: '19px' })}>

--- a/apps/website/src/routes/(default)/[space]/(space)/collections/[collection]/+page@(default).svelte
+++ b/apps/website/src/routes/(default)/[space]/(space)/collections/[collection]/+page@(default).svelte
@@ -160,7 +160,7 @@
               size="sm"
               type="link"
             >
-              첫 회 보기
+              1화 보기
             </Button>
 
             {#if $query.spaceCollection.space.meAsMember}

--- a/apps/website/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
+++ b/apps/website/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
@@ -24,7 +24,7 @@
     smDown: { marginX: '16px', marginY: '20px' },
   })}
 >
-  <h1 class={css({ fontSize: '20px', fontWeight: 'bold' })}>포스트 관리</h1>
+  <h1 class={css({ fontSize: '20px', fontWeight: 'bold' })}>포스트/컬렉션 관리</h1>
   <div>
     <TabHead style={css.raw({ paddingLeft: '0', fontSize: '18px' })}>
       <TabHeadItem id={0} pathname="/{$page.params.space}/dashboard/posts">포스트</TabHeadItem>

--- a/apps/website/src/routes/(default)/[space]/dashboard/posts/collections/+page.svelte
+++ b/apps/website/src/routes/(default)/[space]/dashboard/posts/collections/+page.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import dayjs from 'dayjs';
-  import IconTrash from '~icons/tabler/trash';
   import { graphql } from '$glitch';
-  import { Button, Helmet, Icon, Image } from '$lib/components';
+  import { Button, Helmet, Image } from '$lib/components';
   import {
     CreateCollectionModal,
     ManageCollectionModal,
@@ -51,16 +50,7 @@
     }
   `);
 
-  const deleteSpaceCollection = graphql(`
-    mutation SpaceSettingCollectionPage_deleteSpaceCollection_Mutation($input: DeleteSpaceCollectionInput!) {
-      deleteSpaceCollection(input: $input) {
-        id
-      }
-    }
-  `);
-
   let selectedCollection: (typeof $query.space.collections)[number] | null = null;
-  let deleting = false;
 </script>
 
 <Helmet description={`${$query.space.name} 스페이스 컬렉션 관리`} title={`컬렉션 관리 | ${$query.space.name}`} />
@@ -76,67 +66,46 @@
     <TableHeader>
       <TableRow>
         <TableHead>컬렉션</TableHead>
-        <TableHead style={css.raw({ hideBelow: 'sm' })}>생성일</TableHead>
-        <TableHead>관리</TableHead>
+        <TableHead style={css.raw({ width: '[20%]' })}>수정/관리</TableHead>
       </TableRow>
     </TableHeader>
-    <colgroup>
-      <col span="1" />
-      <col class={css({ width: '128px', hideBelow: 'sm' })} span="1" />
-      <col class={css({ width: '184px', smDown: { width: '80px' } })} span="1" />
-    </colgroup>
     {#each $query.space.collections as collection (collection.id)}
       <TableRow>
         <TableData>
-          <a class={flex({ gap: '12px' })} href={`/${$query.space.slug}/collections/${collection.id}`}>
+          <a
+            class={flex({ align: 'flex-end', gap: '12px' })}
+            href={`/${$query.space.slug}/collections/${collection.id}`}
+          >
             <Image
-              style={css.raw({ flex: 'none', width: '96px', aspectRatio: '[3/4]', flexShrink: 0, objectFit: 'cover' })}
+              style={css.raw({ flex: 'none', width: '48px', aspectRatio: '[3/4]', flexShrink: 0, objectFit: 'cover' })}
               $image={collection.thumbnail}
               placeholder
               size={128}
             />
-            <dl
-              class={css({
-                'overflow': 'hidden',
-                'textOverflow': 'ellipsis',
-                'whiteSpace': 'nowrap',
-                '&>dt': { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
-              })}
-            >
-              <dt class={css({ marginBottom: '4px', fontSize: '15px', fontWeight: 'bold' })}>
+            <dl class={css({ truncate: true })}>
+              <dt class={css({ marginBottom: '4px', fontSize: '15px', fontWeight: 'bold', truncate: true })}>
                 {collection.name}
               </dt>
               <dd
                 class={css({
+                  marginBottom: '4px',
                   fontSize: '13px',
                   fontWeight: 'bold',
                   color: 'gray.500',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'keep-all',
+                  truncate: true,
                 })}
               >
                 {collection.count}개의 포스트
               </dd>
+              <div class={flex({ align: 'center', fontSize: '12px', fontWeight: 'semibold', color: 'gray.400' })}>
+                <dt>생성일:</dt>
+                <dd>{dayjs(collection.createdAt).formatAsDate()}</dd>
+              </div>
             </dl>
           </a>
         </TableData>
-        <TableData style={css.raw({ hideBelow: 'sm', fontSize: '13px', fontWeight: 'bold', color: 'gray.400' })}>
-          {dayjs(collection.createdAt).formatAsDate()}
-        </TableData>
         <TableData>
-          <div class={flex({ gap: '8px' })}>
-            <Button
-              style={css.raw({ hideBelow: 'sm' })}
-              color="tertiary"
-              size="sm"
-              variant="outlined"
-              on:click={() => {
-                selectedCollection = collection;
-                openManageCollectionModal = true;
-              }}
-            >
-              포스트 관리
-            </Button>
+          <div class={flex({ gap: '6px', wrap: 'wrap' })}>
             <Button
               color="tertiary"
               size="sm"
@@ -146,21 +115,18 @@
                 openUpdateCollectionModal = true;
               }}
             >
-              <span class={css({ hideBelow: 'sm', sm: { marginRight: '2px' } })}>컬렉션</span>
-              관리
+              수정
             </Button>
             <Button
-              style={css.raw({ padding: '0', _disabled: { visibility: 'hidden' } })}
-              loading={deleting}
+              color="tertiary"
               size="sm"
-              variant="text"
-              on:click={async () => {
-                deleting = true;
-                await deleteSpaceCollection({ spaceCollectionId: collection.id });
-                deleting = false;
+              variant="outlined"
+              on:click={() => {
+                selectedCollection = collection;
+                openManageCollectionModal = true;
               }}
             >
-              <Icon style={css.raw({ color: 'gray.500', _hover: { color: 'red.600' } })} icon={IconTrash} />
+              관리
             </Button>
           </div>
         </TableData>


### PR DESCRIPTION
|포스트/컬렉션 관리 워딩 수정|컬렉션 삭제 버튼 이동|
|--|--|
<img width="538" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/60bf20e1-db0e-4a9e-927d-5da92add461d">|<img width="432" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/610695f0-c71e-4304-a6e4-fcd1c354f2bf">


- 포스트 관리 -> 관리
- 컬렉션 관리 -> 수정
- 컬렉션 삭제 버튼 -> 컬렉션 수정 모달로 이동
- 모바일에서도 컬렉션 관리 버튼이 보이도록 수정
