### PR TITLE
스페이스 대시보드 레이아웃 안맞는 문제 수정

### DIFF
--- a/apps/website/src/routes/(default)/[space]/dashboard/+layout@.svelte
+++ b/apps/website/src/routes/(default)/[space]/dashboard/+layout@.svelte
@@ -276,7 +276,7 @@
   <div
     class={css({ flex: '1', backgroundColor: 'gray.50', overflow: 'auto', sm: { paddingX: '44px', paddingY: '40px' } })}
   >
-    <div class={css({ width: 'full', maxWidth: '872px' })}>
+    <div class={css({ width: 'full', sm: { maxWidth: '872px' } })}>
       <slot />
     </div>
   </div>


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
<img width="918" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/270aed52-fb91-482f-acd6-82348f4f6e55">|<img width="919" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/77d6165d-6c47-4a40-ad2c-19061801644d">
