### PR TITLE
컬렉션 포스트 재정렬 버그 수정

### DIFF
--- a/apps/website/src/lib/components/pages/collections/ManageCollectionModal.svelte
+++ b/apps/website/src/lib/components/pages/collections/ManageCollectionModal.svelte
@@ -70,7 +70,7 @@
           ...Image_image
         }
 
-        posts {
+        posts(order: OLDEST) {
           id
 
           publishedRevision @_required {


### PR DESCRIPTION
컬렉션 포스트 순서 수정시 매번 순서가 역순이 되는 문제가 있었음
