### PR TITLE
썸네일 피커에서 이미지가 보이는 영역을 실제로 차지하도록 수정

### DIFF
--- a/apps/website/src/lib/components/media/Thumbnailer.svelte
+++ b/apps/website/src/lib/components/media/Thumbnailer.svelte
@@ -38,6 +38,8 @@
   let naturalWidth: number;
   let naturalHeight: number;
 
+  $: fullHeight = boxEl?.clientWidth / boxEl?.clientHeight < naturalWidth / naturalHeight;
+
   let translateX = bounds?.translateX ?? 0;
   let translateY = bounds?.translateY ?? 0;
   let scale = bounds?.scale ?? 1;
@@ -78,27 +80,14 @@
     }
 
     const { width: boxWidth, height: boxHeight } = boxEl.getBoundingClientRect();
-    const { width: imgClientWidth, height: imgClientHeight } = imgEl.getBoundingClientRect();
-
-    const originalRatio = imgEl.naturalWidth / imgEl.naturalHeight; // 이미지의 원본 비율
-    const clientRatio = imgClientWidth / imgClientHeight; // img 요소의 비율
-
-    // object-fit: cover 속성에 의해 확대된 이미지의 크기 계산
-    let imgWidth, imgHeight;
-    if (originalRatio < clientRatio) {
-      imgWidth = imgClientWidth;
-      imgHeight = imgClientWidth / originalRatio;
-    } else {
-      imgWidth = imgClientHeight * originalRatio;
-      imgHeight = imgClientHeight;
-    }
+    const { width: imgWidth, height: imgHeight } = imgEl.getBoundingClientRect();
 
     if (imgWidth === 0 || imgHeight === 0) {
       return;
     }
 
-    const thresholdX = ((imgWidth / 2 - boxWidth / 2) / imgClientWidth) * 100 * scale;
-    const thresholdY = ((imgHeight / 2 - boxHeight / 2) / imgClientHeight) * 100 * scale;
+    const thresholdX = ((imgWidth / 2 - boxWidth / 2) / imgWidth) * 100 * scale;
+    const thresholdY = ((imgHeight / 2 - boxHeight / 2) / imgHeight) * 100 * scale;
 
     translateX = clamp(translateX, -thresholdX, thresholdX);
     translateY = clamp(translateY, -thresholdY, thresholdY);
@@ -136,10 +125,8 @@
       bind:this={imgEl}
       style:transform
       class={css(
-        { objectFit: 'cover', cursor: 'move', touchAction: 'none', overflow: 'visible' },
-        naturalWidth > naturalHeight && { height: 'full' },
-        naturalWidth < naturalHeight && { width: 'full' },
-        naturalWidth === naturalHeight && { size: 'full' },
+        { cursor: 'move', touchAction: 'none', maxWidth: 'none' },
+        fullHeight ? { height: 'full' } : { width: 'full' },
         (!naturalWidth || !naturalHeight) && { display: 'none' },
       )}
       alt=""

--- a/apps/website/src/styles/sizes.ts
+++ b/apps/website/src/styles/sizes.ts
@@ -5,6 +5,7 @@ export const sizes = defineTokens.sizes({
   ...generateREMs(1600),
 
   full: { value: '100%' },
+  none: { value: 'none' },
 
   min: { value: 'min-content' },
   fit: { value: 'fit-content' },


### PR DESCRIPTION
- 한쪽으로 긴 이미지를 다룰 때 img element가 실제 차지하는 정사각형 영역만 드래그가 가능한 버그가 해결됩니다. (#1919 에서 생김..)
- 복잡한 계산 로직이 줄어듭니다.
- 가로, 세로 중 어느쪽을 꽉 채울지 결정할 때 이미지의 ratio 말고도 Thumbnailer의 ratio도 함께 고려합니다. ratio가 'collection', 'post'일 때도 잘 작동합니다.