### PR TITLE
썸네일러 aspect-ratio 제대로 적용되지 않는 버그 수정

### DIFF
--- a/apps/website/src/lib/components/media/Thumbnailer.svelte
+++ b/apps/website/src/lib/components/media/Thumbnailer.svelte
@@ -115,7 +115,7 @@
   <div
     class={center({
       position: 'relative',
-      padding: '32px',
+      padding: '[10%]',
       width: 'full',
       overflow: 'hidden',
       aspectRatio: aspectRatio[ratio],
@@ -153,7 +153,7 @@
       class={css(
         {
           position: 'absolute',
-          inset: '32px',
+          inset: '[10%]',
           borderWidth: '4px',
           borderColor: 'gray.5',
           outlineWidth: '[10000px]',


### PR DESCRIPTION
상하좌우 패딩값이 고정이여서 1:1 비율이 아닐 경우 실제 지정한 aspect-ratio와 틀어지는 문제를 패딩값을 %로 지정해 해결함