### PR TITLE
sveltekit paths.relative=false로 설정

### DIFF
--- a/apps/website/svelte.config.js
+++ b/apps/website/svelte.config.js
@@ -21,6 +21,9 @@ export default {
         client: 'src/hooks/client',
       },
     },
+    paths: {
+      relative: false,
+    },
     typescript: {
       config: (config) => ({
         ...config,


### PR DESCRIPTION
css 불러오는데 가끔 문제가 있는 듯
