### PR TITLE
공유 이미지 생성 시 한자 글리프가 깨지는 문제 고치기

### DIFF
--- a/apps/website/src/lib/server/utils/image.ts
+++ b/apps/website/src/lib/server/utils/image.ts
@@ -170,7 +170,7 @@ export const generatePostShareImage = async ({
               children: body,
               style: {
                 display: 'block',
-                fontFamily: font,
+                fontFamily: `${font}, ${font === 'Pretendard' ? 'sans-serif' : 'serif'}`,
                 fontSize: size === 'small' ? '14px' : size === 'medium' ? '16px' : '18px',
                 // lineHeight: font === 'RIDIBatang' ? '2.215' : '1.875', // 30px for Pretendard, 34px for RIDIBatang
                 lineHeight: font === 'RIDIBatang' ? '34px' : '30px', // 30px for Pretendard, 34px for RIDIBatang


### PR DESCRIPTION
| 출력 | 선택한 문장 |
| :--: | :--: |
| <img src="https://github.com/withglyph/glyph/assets/5278201/ecb764f7-2d4e-4a30-88f0-8e9af091cf84" width="65%"> | ![image](https://github.com/withglyph/glyph/assets/5278201/d01e4364-2e39-4315-9457-dba7bdf86aeb) |


> 재현해보기: [ベクターフィッシュ | 글리프](https://withglyph.com/polaris_observatory/956482871)

시스템 글꼴 sans-serif, serif 를 fallback 으로 설정했습니다.

얼마 전 퇴사 후 갖고 있는 Doppler 및 Tailscale 계정이 없어 PR Preview 를 통해 검수하고자 우선 Draft PR 로 올려둡니다.

---

PS. satori 를 같이 사용 중인 opengraph 이미지 생성 기능에서는 정한 폰트 패밀리에서 지원하고 있어 다행히 해당 문제가 없음을 확인했습니다:

https://github.com/withglyph/glyph/blob/ee703747466ac98a023483c63c5928b1192dfcef/apps/website/src/lib/server/rest/routes/opengraph.ts#L185

> <img src="https://github.com/withglyph/glyph/assets/5278201/835be06a-1ea1-4018-b741-a44351203734" width="50%">
>
> https://withglyph.com/yale/1419574796