### PR TITLE
사파리에서 input이 disabled일 때 폰트 색상이 제대로 표시되지 않는 오류 수정

### DIFF
--- a/apps/website/src/styles/global.ts
+++ b/apps/website/src/styles/global.ts
@@ -46,6 +46,13 @@ export const globalCss = defineGlobalStyles({
     height: 'auto',
   },
 
+  'input': {
+    _disabled: {
+      'opacity': '100',
+      '::-webkit-text-fill-color': '{colors.gray.300}',
+    },
+  },
+
   'ol, ul': {
     listStyle: 'none',
   },


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
|<img width="267" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/cf26cf07-99b7-42d1-b514-584d75716dd3">|<img width="268" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/6940d043-9261-4777-8cfe-3ce85f02f44e">
