### PR TITLE
팁탭 CodeBlock 노드 사용성 개선

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/code-block/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/code-block/Component.svelte
@@ -23,39 +23,49 @@
   let copied = false;
 </script>
 
-<NodeView style={css.raw({ position: 'relative' }, selected && { ringWidth: '2px', ringColor: 'brand.400' })}>
+<NodeView style={css.raw({ paddingY: '8px' })}>
   {#if editor?.isEditable}
-    <div
-      class={flex({
-        align: 'center',
-        justifyContent: 'space-between',
-        paddingTop: '6px',
-        paddingX: '12px',
-        paddingBottom: '4px',
-        backgroundColor: '[#292D3E]',
-        userSelect: 'none',
-      })}
-      contenteditable="false"
-      data-drag-handle
-      draggable
-    >
-      <Select {node} {updateAttributes} />
+    <div class={css(selected && { ringWidth: '2px', ringColor: 'brand.400' })}>
+      <div
+        class={flex({
+          align: 'center',
+          justifyContent: 'space-between',
+          paddingTop: '6px',
+          paddingX: '12px',
+          paddingBottom: '4px',
+          backgroundColor: '[#292D3E]',
+          userSelect: 'none',
+        })}
+        contenteditable="false"
+        data-drag-handle
+        draggable
+      >
+        <Select {node} {updateAttributes} />
 
-      <div class={flex({ align: 'center', gap: '10px', width: '54px' })}>
-        <button class={css({ padding: '4px' })} type="button" on:click={() => deleteNode()}>
-          <Icon style={css.raw({ color: 'gray.300' })} icon={IconTrash} />
-        </button>
+        <div class={flex({ align: 'center', gap: '10px', width: '54px' })}>
+          <button class={css({ padding: '4px' })} type="button" on:click={() => deleteNode()}>
+            <Icon style={css.raw({ color: 'gray.300' })} icon={IconTrash} />
+          </button>
 
-        <div class={css({ padding: '4px' })}>
-          <Icon style={css.raw({ color: 'gray.300' })} icon={IconGripVertical} />
+          <div class={css({ padding: '4px' })}>
+            <Icon style={css.raw({ color: 'gray.300' })} icon={IconGripVertical} />
+          </div>
         </div>
       </div>
-    </div>
 
-    <NodeViewContentEditable
-      style={css.raw({ paddingY: '8px', paddingX: '12px', fontSize: '14px', fontFamily: 'mono', overflowX: 'auto' })}
-      as="pre"
-    />
+      <NodeViewContentEditable
+        style={css.raw({
+          paddingY: '8px',
+          paddingX: '12px',
+          fontSize: '13px',
+          fontFamily: 'mono',
+          color: '[#BABED8]',
+          backgroundColor: '[#292D3E]',
+          overflowX: 'auto',
+        })}
+        as="pre"
+      />
+    </div>
   {:else}
     <div
       class={flex({
@@ -66,6 +76,7 @@
         paddingX: '12px',
         paddingBottom: '4px',
         height: '34px',
+        backgroundColor: '[#292D3E]',
       })}
     >
       <div
@@ -107,8 +118,10 @@
       style={css.raw({
         paddingY: '8px',
         paddingX: '12px',
-        fontSize: '14px',
+        fontSize: '13px',
         fontFamily: 'mono',
+        color: '[#BABED8]',
+        backgroundColor: '[#292D3E]',
         userSelect: 'text',
         overflowX: 'auto',
       })}

--- a/apps/website/src/lib/tiptap/node-views/code-block/index.ts
+++ b/apps/website/src/lib/tiptap/node-views/code-block/index.ts
@@ -32,6 +32,7 @@ export const CodeBlock = createNodeView<Options, Storage>(Component, {
   marks: '',
   code: true,
   defining: true,
+  isolating: true,
 
   addOptions() {
     return {
@@ -61,6 +62,32 @@ export const CodeBlock = createNodeView<Options, Storage>(Component, {
 
           return tr.docChanged;
         },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Backspace': ({ editor }) => {
+        const { $anchor, empty } = editor.state.selection;
+
+        if (!empty || $anchor.parent.type !== this.type || $anchor.parent.textContent.length > 0) {
+          return false;
+        }
+
+        return true;
+      },
+
+      'Mod-a': ({ editor }) => {
+        const { $anchor } = editor.state.selection;
+        if ($anchor.parent.type !== this.type) {
+          return false;
+        }
+
+        return editor.commands.setTextSelection({
+          from: $anchor.start(),
+          to: $anchor.end(),
+        });
+      },
     };
   },
 
@@ -120,12 +147,6 @@ const getDecorations = (highlighter: Highlighter, theme: BundledTheme, doc: Node
     const lang = child.node.attrs.language;
 
     const result = highlighter.codeToTokens(child.node.textContent, { theme, lang });
-
-    decorations.push(
-      Decoration.node(child.pos, child.pos + child.node.nodeSize, {
-        style: themedTokenToStyle({ color: result.fg, bgColor: result.bg, htmlStyle: result.rootStyle }),
-      }),
-    );
 
     for (const token of result.tokens.flat()) {
       const from = child.pos + token.offset + 1;


### PR DESCRIPTION
- 언어 선택 드롭다운시 현재 선택된 언어가 목록 중심에 나타나도록 변경
- 언어 선택 드롭다운 닫을 때 검색창 초기화
- 언어 선택 드롭다운 열려 있을 때 Esc 키로 닫을 수 있게 함
- 노드 위아래로 패딩 추가
- 코드 폰트 사이즈 14px -> 13px
- 언어 목록에 Plain Text 추가
- 코드 블럭 안에서 커서가 제일 앞에 있을 때 백스페이스 키로 코드블럭이 안 지워지도록 수정
- 코드 블럭 노드에 `isolating` 추가로 코드 블럭 사이에 갭 커서 생성될 수 있도록 함
- 코드 블럭 안에서 Mod-a 누를 시 코드 블럭 내의 텍스트만 전체 선택하도록 함
