### PR TITLE
팁탭 HTML 노드 사용성 개선

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/html/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/html/Component.svelte
@@ -17,49 +17,59 @@
   export let deleteNode: NodeViewProps['deleteNode'];
 </script>
 
-<NodeView style={css.raw({ position: 'relative' }, selected && { ringWidth: '2px', ringColor: 'brand.400' })}>
+<NodeView style={css.raw({ paddingY: '8px' })}>
   {#if editor?.isEditable}
-    <div
-      class={flex({
-        align: 'center',
-        paddingTop: '6px',
-        paddingX: '12px',
-        paddingBottom: '4px',
-        backgroundColor: '[#292D3E]',
-        userSelect: 'none',
-      })}
-      contenteditable="false"
-      data-drag-handle
-      draggable
-    >
+    <div class={css(selected && { ringWidth: '2px', ringColor: 'brand.400' })}>
       <div
-        class={css({
-          flexGrow: '1',
-          paddingLeft: '54px',
-          fontSize: '14px',
-          fontWeight: 'medium',
-          color: 'gray.50',
-          textAlign: 'center',
+        class={flex({
+          align: 'center',
+          paddingTop: '6px',
+          paddingX: '12px',
+          paddingBottom: '4px',
+          backgroundColor: '[#292D3E]',
+          userSelect: 'none',
         })}
+        contenteditable="false"
+        data-drag-handle
+        draggable
       >
-        HTML
-      </div>
+        <div
+          class={css({
+            flexGrow: '1',
+            paddingLeft: '54px',
+            fontSize: '14px',
+            fontWeight: 'medium',
+            color: 'gray.50',
+            textAlign: 'center',
+          })}
+        >
+          HTML
+        </div>
 
-      <div class={flex({ align: 'center', gap: '10px', width: '54px' })}>
-        <button class={css({ padding: '4px' })} type="button" on:click={() => deleteNode()}>
-          <Icon style={css.raw({ color: 'gray.300' })} icon={IconTrash} />
-        </button>
+        <div class={flex({ align: 'center', gap: '10px', width: '54px' })}>
+          <button class={css({ padding: '4px' })} type="button" on:click={() => deleteNode()}>
+            <Icon style={css.raw({ color: 'gray.300' })} icon={IconTrash} />
+          </button>
 
-        <div class={css({ padding: '4px' })}>
-          <Icon style={css.raw({ color: 'gray.300' })} icon={IconGripVertical} />
+          <div class={css({ padding: '4px' })}>
+            <Icon style={css.raw({ color: 'gray.300' })} icon={IconGripVertical} />
+          </div>
         </div>
       </div>
-    </div>
 
-    <NodeViewContentEditable
-      style={css.raw({ paddingY: '8px', paddingX: '12px', fontSize: '14px', fontFamily: 'mono', overflowX: 'auto' })}
-      as="pre"
-    />
+      <NodeViewContentEditable
+        style={css.raw({
+          paddingY: '8px',
+          paddingX: '12px',
+          fontSize: '13px',
+          fontFamily: 'mono',
+          color: '[#BABED8]',
+          backgroundColor: '[#292D3E]',
+          overflowX: 'auto',
+        })}
+        as="pre"
+      />
+    </div>
   {:else}
     <div
       class={css({

--- a/apps/website/src/lib/tiptap/node-views/html/index.ts
+++ b/apps/website/src/lib/tiptap/node-views/html/index.ts
@@ -32,6 +32,7 @@ export const Html = createNodeView<Options, Storage>(Component, {
   marks: '',
   code: true,
   defining: true,
+  isolating: true,
 
   addOptions() {
     return {
@@ -55,6 +56,32 @@ export const Html = createNodeView<Options, Storage>(Component, {
 
           return tr.docChanged;
         },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Backspace': ({ editor }) => {
+        const { $anchor, empty } = editor.state.selection;
+
+        if (!empty || $anchor.parent.type !== this.type || $anchor.parent.textContent.length > 0) {
+          return false;
+        }
+
+        return true;
+      },
+
+      'Mod-a': ({ editor }) => {
+        const { $anchor } = editor.state.selection;
+        if ($anchor.parent.type !== this.type) {
+          return false;
+        }
+
+        return editor.commands.setTextSelection({
+          from: $anchor.start(),
+          to: $anchor.end(),
+        });
+      },
     };
   },
 
@@ -116,12 +143,6 @@ const getDecorations = (highlighter: Highlighter, theme: BuiltinTheme, doc: Node
   const children = findChildren(doc, (node) => node.type.name === 'html');
   for (const child of children) {
     const result = highlighter.codeToTokens(child.node.textContent, { theme, lang: 'html' });
-
-    decorations.push(
-      Decoration.node(child.pos, child.pos + child.node.nodeSize, {
-        style: themedTokenToStyle({ color: result.fg, bgColor: result.bg, htmlStyle: result.rootStyle }),
-      }),
-    );
 
     for (const token of result.tokens.flat()) {
       const from = child.pos + token.offset + 1;


### PR DESCRIPTION
- 노드 위아래로 패딩 추가
- HTML 블럭 안에서 커서가 제일 앞에 있을 때 백스페이스 키로 HTML 블럭이 안 지워지도록 수정
- HTML 블럭 노드에 `isolating` 추가로 HTML 블럭 사이에 갭 커서 생성될 수 있도록 함
- HTML 블럭 안에서 Mod-a 누를 시 HTML 블럭 내의 텍스트만 전체 선택하도록 함
