### PR TITLE
팁탭 SSR시 레이아웃 시프트 버그 수정

### DIFF
--- a/apps/website/src/lib/tiptap/components/TiptapRenderer.svelte
+++ b/apps/website/src/lib/tiptap/components/TiptapRenderer.svelte
@@ -29,7 +29,7 @@
         attributes: { class: css(style) },
       },
 
-      onCreate: () => {
+      onBeforeCreate: () => {
         loaded = true;
       },
     });

--- a/apps/website/src/lib/tiptap/lib/create.ts
+++ b/apps/website/src/lib/tiptap/lib/create.ts
@@ -1,4 +1,4 @@
-import { Node } from '@tiptap/core';
+import { mergeAttributes, Node } from '@tiptap/core';
 import { browser } from '$app/environment';
 import { SvelteNodeViewRenderer } from './renderer';
 import type { NodeConfig } from '@tiptap/core';
@@ -18,9 +18,9 @@ export const createNodeView = <Options = any, Storage = any>(
       return [{ tag: 'node-view' }];
     },
 
-    renderHTML({ node }) {
+    renderHTML({ node, HTMLAttributes }) {
       if (browser) {
-        return ['node-view'];
+        return ['node-view', HTMLAttributes];
       } else {
         // @ts-expect-error svelte internal
         const { html } = component.render({
@@ -29,7 +29,7 @@ export const createNodeView = <Options = any, Storage = any>(
           selected: false,
         });
 
-        return ['node-view', { html, style: 'white-space: normal;' }];
+        return ['node-view', mergeAttributes(HTMLAttributes, { html, style: 'white-space: normal;' })];
       }
     },
 


### PR DESCRIPTION
ssr시에 tick 이슈로 팁탭 에디터 객체와 ssr html 결과물이 1프레임정도 동시에 존재하는 현상 수정
