### PR TITLE
팁탭 문단 사이간격 옵션이 정말 문단 사이에만 적용되도록 수정함

### DIFF
--- a/apps/website/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/website/src/lib/tiptap/nodes/paragraph.ts
@@ -81,8 +81,10 @@ export const Paragraph = Node.create({
       mergeAttributes(HTMLAttributes, {
         class: css(
           node.attrs.textAlign === 'left' && {
-            marginBottom: 'var(--document-paragraph-spacing)',
-            textIndent: 'var(--document-paragraph-indent)',
+            'textIndent': 'var(--document-paragraph-indent)',
+            '& + &': {
+              marginTop: 'var(--document-paragraph-spacing)',
+            },
           },
         ),
       }),


### PR DESCRIPTION
모든 `paragraph` 블럭에 `margin-bottom` 적용하는 것이 아닌 `paragraph + paragraph` 일 때만 사이에 간격 적용함
