### PR TITLE
Post.contentSnapshots 불러오는 로직 최적화

### DIFF
--- a/apps/website/src/lib/server/graphql/schemas/post.ts
+++ b/apps/website/src/lib/server/graphql/schemas/post.ts
@@ -325,13 +325,11 @@ Post.implement({
           }
         }
 
-        const snapshots = await database
-          .select({ id: PostContentSnapshots.id })
+        return await database
+          .select()
           .from(PostContentSnapshots)
           .where(eq(PostContentSnapshots.postId, post.id))
           .orderBy(asc(PostContentSnapshots.createdAt));
-
-        return snapshots.map((update) => update.id);
       },
     }),
 


### PR DESCRIPTION
ids가 엄청 많을거라 굳이 id 리턴 안 하고 그냥 객체 그대로 리턴하도록 최적화함
