### PR TITLE
포스트에서 유료분량 오버뷰 못 불러오는 버그 수정

### DIFF
--- a/apps/website/src/lib/server/graphql/schemas/post.ts
+++ b/apps/website/src/lib/server/graphql/schemas/post.ts
@@ -754,14 +754,12 @@ PostRevision.implement({
     freeContent: t.field({
       type: PostRevisionContent,
       nullable: true,
-      authScopes: { $granted: '$postRevision:view' },
       resolve: (revision) => revision.freeContentId,
     }),
 
     paidContent: t.field({
       type: PostRevisionContent,
       nullable: true,
-      authScopes: { $granted: '$postRevision:view' },
       resolve: (revision) => revision.paidContentId,
     }),
 


### PR DESCRIPTION
PostRevisionContent graphql 타입은 내용이 안 들어있고 메타데이터만 들어있는 타입이라 내려보내도 됨
