### PR TITLE
에디터 첫 로딩시 결제선이 선택되어 있는 버그 수정

### DIFF
--- a/apps/website/src/lib/tiptap/extensions/collaboration.ts
+++ b/apps/website/src/lib/tiptap/extensions/collaboration.ts
@@ -1,4 +1,5 @@
 import { Extension } from '@tiptap/core';
+import { Plugin, TextSelection } from '@tiptap/pm/state';
 import { redo, undo, yCursorPlugin, ySyncPlugin, yUndoPlugin, yUndoPluginKey } from 'y-prosemirror';
 import * as YAwareness from 'y-protocols/awareness';
 import * as Y from 'yjs';
@@ -149,6 +150,19 @@ export const Collaboration = Extension.create<CollaborationOptions>({
       ySyncPlugin(fragment),
       yUndoPluginInstance,
       yCursorPlugin(this.options.awareness, { cursorBuilder, selectionBuilder }),
+      new Plugin({
+        appendTransaction: (_, __, newState) => {
+          const { $anchor, $head } = newState.selection;
+
+          if ($anchor.pos === newState.doc.content.size && $head.pos === newState.doc.content.size) {
+            const { tr } = newState;
+            tr.setSelection(TextSelection.create(newState.doc, 0, 0));
+            return tr;
+          }
+
+          return null;
+        },
+      }),
     ];
   },
 


### PR DESCRIPTION
에디터 첫 로딩시 결제선이 선택되어 보라색 박스가 나타나는 현상을 workaround 함
