### PR TITLE
이미지 버블메뉴 버튼 순서 조정 및 스타일 수정

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/gallery/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/gallery/Component.svelte
@@ -10,7 +10,6 @@
   import { NodeView } from '$lib/tiptap';
   import { TiptapNodeViewBubbleMenu } from '$lib/tiptap/components';
   import { css } from '$styled-system/css';
-  import { flex } from '$styled-system/patterns';
   import Image from './Image.svelte';
   import ItemEditor from './ItemEditor.svelte';
   import Slide from './Slide.svelte';
@@ -69,10 +68,8 @@
 {#if editor && selected}
   <TiptapNodeViewBubbleMenu {editor} {getPos} {node}>
     <button
-      class={flex({
-        align: 'center',
-        gap: '6px',
-        padding: '2px',
+      class={css({
+        margin: '2px',
         paddingRight: '4px',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
@@ -80,73 +77,17 @@
       type="button"
       on:click={() => (openItemEditor = true)}
     >
-      <Icon icon={IconEdit} size={20} />
-      편집
+      <Icon style={css.raw({ size: '18px' })} icon={IconEdit} />
     </button>
 
     <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
 
-    {#if node.attrs.size === 'compact'}
-      <button
-        class={css({
-          padding: '2px',
-          transition: 'common',
-          _hover: { backgroundColor: 'gray.100' },
-          _pressed: { backgroundColor: { base: 'gray.800', _hover: 'gray.600' }, color: 'gray.50' },
-        })}
-        aria-pressed={node.attrs.align === 'left'}
-        type="button"
-        on:click={() => {
-          updateAttributes({ align: 'left' });
-          editor?.commands.focus();
-        }}
-      >
-        <Icon icon={IconAlignLeft} size={20} />
-      </button>
-
-      <button
-        class={css({
-          padding: '2px',
-          transition: 'common',
-          _hover: { backgroundColor: 'gray.100' },
-          _pressed: { backgroundColor: { base: 'gray.800', _hover: 'gray.600' }, color: 'gray.50' },
-        })}
-        aria-pressed={node.attrs.align === 'center'}
-        type="button"
-        on:click={() => {
-          updateAttributes({ align: 'center' });
-          editor?.commands.focus();
-        }}
-      >
-        <Icon icon={IconAlignCenter} size={20} />
-      </button>
-
-      <button
-        class={css({
-          padding: '2px',
-          transition: 'common',
-          _hover: { backgroundColor: 'gray.100' },
-          _pressed: { backgroundColor: { base: 'gray.800', _hover: 'gray.600' }, color: 'gray.50' },
-        })}
-        aria-pressed={node.attrs.align === 'right'}
-        type="button"
-        on:click={() => {
-          updateAttributes({ align: 'right' });
-          editor?.commands.focus();
-        }}
-      >
-        <Icon icon={IconAlignRight} size={20} />
-      </button>
-
-      <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
-    {/if}
-
     <button
       class={css({
-        padding: '2px',
+        margin: '2px',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
-        _pressed: { backgroundColor: { base: 'gray.800', _hover: 'gray.600' }, color: 'gray.50' },
+        _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
       })}
       aria-pressed={node.attrs.size === 'full'}
       type="button"
@@ -155,14 +96,14 @@
         editor?.commands.focus();
       }}
     >
-      <Icon icon={IconEmbedFull} size={20} />
+      <Icon style={css.raw({ size: '18px' })} icon={IconEmbedFull} />
     </button>
     <button
       class={css({
-        padding: '2px',
+        margin: '2px',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
-        _pressed: { backgroundColor: { base: 'gray.800', _hover: 'gray.600' }, color: 'gray.50' },
+        _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
       })}
       aria-pressed={node.attrs.size === 'compact'}
       type="button"
@@ -171,21 +112,76 @@
         editor?.commands.focus();
       }}
     >
-      <Icon icon={IconEmbedCompact} size={20} />
+      <Icon style={css.raw({ size: '18px' })} icon={IconEmbedCompact} />
     </button>
 
     <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
 
+    {#if node.attrs.size === 'compact'}
+      <button
+        class={css({
+          margin: '2px',
+          transition: 'common',
+          _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
+        })}
+        aria-pressed={node.attrs.align === 'left'}
+        type="button"
+        on:click={() => {
+          updateAttributes({ align: 'left' });
+          editor?.commands.focus();
+        }}
+      >
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignLeft} />
+      </button>
+
+      <button
+        class={css({
+          margin: '2px',
+          transition: 'common',
+          _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
+        })}
+        aria-pressed={node.attrs.align === 'center'}
+        type="button"
+        on:click={() => {
+          updateAttributes({ align: 'center' });
+          editor?.commands.focus();
+        }}
+      >
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignCenter} />
+      </button>
+
+      <button
+        class={css({
+          margin: '2px',
+          transition: 'common',
+          _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
+        })}
+        aria-pressed={node.attrs.align === 'right'}
+        type="button"
+        on:click={() => {
+          updateAttributes({ align: 'right' });
+          editor?.commands.focus();
+        }}
+      >
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignRight} />
+      </button>
+
+      <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
+    {/if}
+
     <button
       class={css({
-        padding: '2px',
+        margin: '2px',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
       })}
       type="button"
       on:click={() => deleteNode()}
     >
-      <Icon style={css.raw({ color: 'gray.600' })} icon={IconTrash} size={20} />
+      <Icon style={css.raw({ color: 'gray.600', size: '18px' })} icon={IconTrash} />
     </button>
   </TiptapNodeViewBubbleMenu>
 

--- a/apps/website/src/lib/tiptap/node-views/image/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/image/Component.svelte
@@ -74,65 +74,91 @@
 
 {#if editor && selected}
   <TiptapNodeViewBubbleMenu {editor} {getPos} {node}>
+    <button
+      class={css({
+        margin: '2px',
+        transition: 'common',
+        _hover: { backgroundColor: 'gray.100' },
+        _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
+      })}
+      aria-pressed={node.attrs.size === 'full'}
+      type="button"
+      on:click={() => {
+        updateAttributes({ size: 'full' });
+        editor?.commands.focus();
+      }}
+    >
+      <Icon style={css.raw({ size: '18px' })} icon={IconEmbedFull} />
+    </button>
+    <button
+      class={css({
+        margin: '2px',
+        transition: 'common',
+        _hover: { backgroundColor: 'gray.100' },
+        _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
+      })}
+      aria-pressed={node.attrs.size === 'compact'}
+      type="button"
+      on:click={() => {
+        updateAttributes({ size: 'compact' });
+        editor?.commands.focus();
+      }}
+    >
+      <Icon style={css.raw({ size: '18px' })} icon={IconEmbedCompact} />
+    </button>
+
+    <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
+
     {#if node.attrs.size === 'compact'}
       <button
         class={css({
-          borderRadius: '2px',
-          padding: '4px',
+          margin: '2px',
           transition: 'common',
           _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
         })}
+        aria-pressed={node.attrs.align === 'left'}
         type="button"
         on:click={() => {
           updateAttributes({ align: 'left' });
           editor?.commands.focus();
         }}
       >
-        <Icon
-          style={css.raw({ color: 'gray.600' }, node.attrs.align === 'left' && { color: 'brand.400' })}
-          icon={IconAlignLeft}
-          size={20}
-        />
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignLeft} />
       </button>
 
       <button
         class={css({
-          borderRadius: '2px',
-          padding: '4px',
+          margin: '2px',
           transition: 'common',
           _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
         })}
+        aria-pressed={node.attrs.align === 'center'}
         type="button"
         on:click={() => {
           updateAttributes({ align: 'center' });
           editor?.commands.focus();
         }}
       >
-        <Icon
-          style={css.raw({ color: 'gray.600' }, node.attrs.align === 'center' && { color: 'brand.400' })}
-          icon={IconAlignCenter}
-          size={20}
-        />
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignCenter} />
       </button>
 
       <button
         class={css({
-          borderRadius: '2px',
-          padding: '4px',
+          margin: '2px',
           transition: 'common',
           _hover: { backgroundColor: 'gray.100' },
+          _pressed: { backgroundColor: { base: 'brand.400', _hover: 'brand.600' }, color: 'gray.50' },
         })}
+        aria-pressed={node.attrs.align === 'right'}
         type="button"
         on:click={() => {
           updateAttributes({ align: 'right' });
           editor?.commands.focus();
         }}
       >
-        <Icon
-          style={css.raw({ color: 'gray.600' }, node.attrs.align === 'right' && { color: 'brand.400' })}
-          icon={IconAlignRight}
-          size={20}
-        />
+        <Icon style={css.raw({ size: '18px' })} icon={IconAlignRight} />
       </button>
 
       <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
@@ -140,56 +166,14 @@
 
     <button
       class={css({
-        borderRadius: '2px',
-        padding: '4px',
-        transition: 'common',
-        _hover: { backgroundColor: 'gray.100' },
-      })}
-      type="button"
-      on:click={() => {
-        updateAttributes({ size: 'full' });
-        editor?.commands.focus();
-      }}
-    >
-      <Icon
-        style={css.raw({ color: 'gray.600' }, node.attrs.size === 'full' && { color: 'brand.400' })}
-        icon={IconEmbedFull}
-        size={20}
-      />
-    </button>
-    <button
-      class={css({
-        borderRadius: '2px',
-        padding: '4px',
-        transition: 'common',
-        _hover: { backgroundColor: 'gray.100' },
-      })}
-      type="button"
-      on:click={() => {
-        updateAttributes({ size: 'compact' });
-        editor?.commands.focus();
-      }}
-    >
-      <Icon
-        style={css.raw({ color: 'gray.600' }, node.attrs.size === 'compact' && { color: 'brand.400' })}
-        icon={IconEmbedCompact}
-        size={20}
-      />
-    </button>
-
-    <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />
-
-    <button
-      class={css({
-        borderRadius: '2px',
-        padding: '4px',
+        margin: '2px',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
       })}
       type="button"
       on:click={() => deleteNode()}
     >
-      <Icon style={css.raw({ color: 'gray.600' })} icon={IconTrash} size={20} />
+      <Icon style={css.raw({ color: 'gray.600', size: '18px' })} icon={IconTrash} />
     </button>
   </TiptapNodeViewBubbleMenu>
 {/if}


### PR DESCRIPTION
- 버튼 크기 20 -> 18로 수정
- 버튼 여백 수정
- 툴바가 더 잘 보이도록 버블메뉴 버튼의 pressed 상태일 때 툴바와 동일한 brand 색상으로 변경
- 툴바에 있는 순서대로 이미지 정렬 버튼들을 오른쪽으로 이동시킴
