### PR TITLE
이미지 편집 툴바에서 그룹편집/이미지 교체 버튼 삭제

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/gallery/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/gallery/Component.svelte
@@ -10,6 +10,7 @@
   import { NodeView } from '$lib/tiptap';
   import { TiptapNodeViewBubbleMenu } from '$lib/tiptap/components';
   import { css } from '$styled-system/css';
+  import { flex } from '$styled-system/patterns';
   import Image from './Image.svelte';
   import ItemEditor from './ItemEditor.svelte';
   import Slide from './Slide.svelte';
@@ -68,9 +69,13 @@
 {#if editor && selected}
   <TiptapNodeViewBubbleMenu {editor} {getPos} {node}>
     <button
-      class={css({
-        margin: '2px',
+      class={flex({
+        align: 'center',
+        gap: '2px',
+        padding: '2px',
         paddingRight: '4px',
+        fontSize: '12px',
+        fontWeight: 'medium',
         transition: 'common',
         _hover: { backgroundColor: 'gray.100' },
       })}
@@ -78,6 +83,7 @@
       on:click={() => (openItemEditor = true)}
     >
       <Icon style={css.raw({ size: '18px' })} icon={IconEdit} />
+      그룹편집
     </button>
 
     <div class={css({ backgroundColor: 'gray.200', width: '1px', height: '12px' })} />

--- a/apps/website/src/routes/editor/[permalink]/GalleryEditToolbar.svelte
+++ b/apps/website/src/routes/editor/[permalink]/GalleryEditToolbar.svelte
@@ -11,8 +11,6 @@
   import IconAlignCenter from '~icons/tabler/align-center';
   import IconAlignLeft from '~icons/tabler/align-left';
   import IconAlignRight from '~icons/tabler/align-right';
-  import IconEdit from '~icons/tabler/edit';
-  import { Icon } from '$lib/components';
   import { css } from '$styled-system/css';
   import { flex } from '$styled-system/patterns';
   import { getEditorContext } from './context';
@@ -22,7 +20,7 @@
   $: editor = $state.editor;
 </script>
 
-<hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
+<!-- <hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
 
 <button
   class={flex({
@@ -37,7 +35,7 @@
 >
   <Icon icon={IconEdit} size={20} />
   그룹 편집
-</button>
+</button> -->
 
 <hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
 

--- a/apps/website/src/routes/editor/[permalink]/ImageEditToolbar.svelte
+++ b/apps/website/src/routes/editor/[permalink]/ImageEditToolbar.svelte
@@ -4,8 +4,6 @@
   import IconAlignCenter from '~icons/tabler/align-center';
   import IconAlignLeft from '~icons/tabler/align-left';
   import IconAlignRight from '~icons/tabler/align-right';
-  import IconArrowsExchange from '~icons/tabler/arrows-exchange';
-  import { Icon } from '$lib/components';
   import { css } from '$styled-system/css';
   import { flex } from '$styled-system/patterns';
   import { getEditorContext } from './context';
@@ -15,7 +13,7 @@
   $: editor = $state.editor;
 </script>
 
-<hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
+<!-- <hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
 
 <button
   class={flex({
@@ -30,7 +28,7 @@
 >
   <Icon icon={IconArrowsExchange} size={20} />
   이미지 교체
-</button>
+</button> -->
 
 <hr class={css({ border: 'none', width: '1px', height: '12px', backgroundColor: '[#DAD7E2]' })} />
 


### PR DESCRIPTION
일단 임시로 버블메뉴에만 넣어놓기로 함