### PR TITLE
발행메뉴가 에디터 헤더와 맞는 위치에 있도록 수정

### DIFF
--- a/apps/website/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/website/src/routes/editor/[permalink]/Header.svelte
@@ -92,7 +92,7 @@
 
   const { anchor: publishAnchor, floating: publishFloating } = createFloatingActions({
     placement: 'bottom-end',
-    offset: 11,
+    offset: 13,
   });
 
   let vvOffset: number | undefined;


### PR DESCRIPTION
|위: 수정 전 / 아래: 수정 후|
|--|
|<img width="747" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/4d750a80-f219-4a6d-ad19-6158a9d6c6af">|
|<img width="744" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/b0ee4cbc-3b06-4aca-91e8-030b0e5c9da2">|
