### PR TITLE
팁탭 Paragraph 노드의 정렬이 justify일 때도 text-indent 설정하도록 함

### DIFF
--- a/apps/website/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/website/src/lib/tiptap/nodes/paragraph.ts
@@ -83,7 +83,7 @@ export const Paragraph = Node.create({
       mergeAttributes(HTMLAttributes, {
         class: css(
           { '& + &': { marginTop: 'var(--document-paragraph-spacing)' } },
-          node.attrs.textAlign === 'left' && {
+          (node.attrs.textAlign === 'left' || node.attrs.textAlign === 'justify') && {
             textIndent: 'var(--document-paragraph-indent)',
           },
         ),


### PR DESCRIPTION
양쪽정렬일 때 문단 들여쓰기 적용 안 되는 버그 수정
