### PR TITLE
sveltekit이 상황에 맞는 http error code로 응답하도록 수정

### DIFF
--- a/apps/website/src/lib/errors/index.ts
+++ b/apps/website/src/lib/errors/index.ts
@@ -25,12 +25,17 @@ type AppErrorConstructorParams = {
 };
 
 export type PortableAppError = z.infer<typeof PortableAppErrorSchema>;
-const PortableAppErrorSchema = z.object({
+export const PortableAppErrorSchema = z.object({
   message: z.string(),
   extensions: z.object({
     __app: z.object({
       kind: z.nativeEnum(AppErrorKind),
-      extra: z.record(z.unknown()),
+      extra: z
+        .object({
+          code: z.number().optional(),
+          internal: z.boolean().optional(),
+        })
+        .passthrough(),
     }),
   }),
 });

--- a/apps/website/src/lib/glitch/index.ts
+++ b/apps/website/src/lib/glitch/index.ts
@@ -1,17 +1,34 @@
+import { error as throwError } from '@sveltejs/kit';
 import { createClient } from '@withglyph/glitch';
-import { AppError } from '$lib/errors';
+import { AppError, PortableAppErrorSchema } from '$lib/errors';
 import { toast } from '$lib/notification';
 import { keys } from './keys';
 import { optimistic } from './optimistic';
 import { updates } from './updates';
+import type { HttpError } from '@sveltejs/kit';
 
 // eslint-disable-next-line import/no-default-export
 export default createClient({
   url: '/api/graphql',
   cache: { keys, optimistic, updates },
-  transformError: AppError.deserialize,
+  transformError: (type, error) => {
+    if (type === 'mutation') {
+      return AppError.deserialize(error);
+    } else {
+      const r = PortableAppErrorSchema.safeParse(error);
+      try {
+        if (r.success) {
+          throwError(r.data.extensions.__app.extra.code ?? 500, r.data);
+        } else {
+          throwError(500);
+        }
+      } catch (err) {
+        return err as HttpError;
+      }
+    }
+  },
   onMutationError: (error) => {
-    if (!error.extra.internal) {
+    if (error instanceof AppError && !error.extra.internal) {
       toast(error.message);
     }
   },

--- a/packages/glitch/src/client/index.ts
+++ b/packages/glitch/src/client/index.ts
@@ -11,7 +11,8 @@ import type { GlitchClient } from '../types';
 type CreateClientParams<E> = {
   url: string;
   cache: CacheExchangeOpts;
-  transformError: (error: unknown) => E;
+  transformError: ((type: 'query' | 'subscription', error: unknown) => unknown) &
+    ((type: 'mutation', error: unknown) => E);
   onMutationError: (error: E) => void;
 };
 

--- a/packages/glitch/src/store/mutation.ts
+++ b/packages/glitch/src/store/mutation.ts
@@ -27,13 +27,13 @@ export const createMutationStore = (document: TypedDocumentNode<unknown, AnyVari
     );
 
     if (result.error?.networkError) {
-      const err = transformError(result.error.networkError);
+      const err = transformError('mutation', result.error.networkError);
       onMutationError(err);
       throw err;
     }
 
     if (result.error?.graphQLErrors.length) {
-      const err = transformError(result.error.graphQLErrors[0]);
+      const err = transformError('mutation', result.error.graphQLErrors[0]);
       onMutationError(err);
       throw err;
     }

--- a/packages/glitch/src/store/query.ts
+++ b/packages/glitch/src/store/query.ts
@@ -28,11 +28,11 @@ export const createQueryStore = async (
   );
 
   if (result.error?.networkError) {
-    throw transformError(result.error.networkError);
+    throw transformError('query', result.error.networkError);
   }
 
   if (result.error?.graphQLErrors.length) {
-    throw transformError(result.error.graphQLErrors[0]);
+    throw transformError('query', result.error.graphQLErrors[0]);
   }
 
   const { source, next } = makeSubject<GraphQLRequest>();
@@ -74,11 +74,11 @@ export const createQueryStore = async (
       );
 
       if (result.error?.networkError) {
-        throw transformError(result.error.networkError);
+        throw transformError('query', result.error.networkError);
       }
 
       if (result.error?.graphQLErrors.length) {
-        throw transformError(result.error.graphQLErrors[0]);
+        throw transformError('query', result.error.graphQLErrors[0]);
       }
 
       next(request);
@@ -132,11 +132,11 @@ export const createManualQueryStore = (document: TypedDocumentNode<unknown, AnyV
       );
 
       if (result.error?.networkError) {
-        throw transformError(result.error.networkError);
+        throw transformError('query', result.error.networkError);
       }
 
       if (result.error?.graphQLErrors.length) {
-        throw transformError(result.error.graphQLErrors[0]);
+        throw transformError('query', result.error.graphQLErrors[0]);
       }
 
       next(request);

--- a/packages/glitch/src/store/subscription.ts
+++ b/packages/glitch/src/store/subscription.ts
@@ -20,11 +20,11 @@ export const createSubscriptionStore = (document: TypedDocumentNode<unknown, Any
       filter(({ stale }) => !stale),
       tap((result) => {
         if (result.error?.networkError) {
-          throw transformError(result.error.networkError);
+          throw transformError('subscription', result.error.networkError);
         }
 
         if (result.error?.graphQLErrors.length) {
-          throw transformError(result.error.graphQLErrors[0]);
+          throw transformError('subscription', result.error.graphQLErrors[0]);
         }
       }),
       map(({ data }) => data),

--- a/packages/glitch/src/types.ts
+++ b/packages/glitch/src/types.ts
@@ -61,7 +61,8 @@ export type GlitchContext = {
 
 export type GlitchClient<E = Error> = {
   client: Client;
-  transformError: (error: unknown) => E;
+  transformError: ((type: 'query' | 'subscription', error: unknown) => unknown) &
+    ((type: 'mutation', error: unknown) => E);
   onMutationError: (error: E) => void;
 };
 


### PR DESCRIPTION
지금까지는 서버에서 NotFoundError 등을 던져도 sveltekit에서 500으로 응답하던걸 수정함
