### PR TITLE
이미지 확대 뷰어의 이미지가 화면 높이보다 작을 경우 중앙정렬되도록 수정

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/gallery/ImageViewer.svelte
+++ b/apps/website/src/lib/tiptap/node-views/gallery/ImageViewer.svelte
@@ -223,6 +223,7 @@
     {:else}
       <div
         class={css(
+          { marginY: 'auto' },
           node.attrs.layout === 'scroll' && { display: 'flex', flexDirection: 'column', alignItems: 'center' },
           node.attrs.layout === 'grid-2' && { display: 'grid', gridTemplateColumns: '2' },
           node.attrs.layout === 'grid-3' && { display: 'grid', gridTemplateColumns: '3' },


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
|<img width="739" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/bf3d765e-e114-451e-afb1-7a9e620a738d">|<img width="740" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/806b7124-5f2e-4351-ad6f-4ef4fdbb6464">
