### PR TITLE
TextInput 디자인 변경사항 반영

### DIFF
--- a/apps/website/src/lib/components/ShareLinkPopover.svelte
+++ b/apps/website/src/lib/components/ShareLinkPopover.svelte
@@ -190,11 +190,11 @@
       })}
     >
       <div class={css({ flexGrow: '1', minWidth: '0' })}>
-        <TextInput readonly size="sm" type="text" value={href} />
+        <TextInput readonly size="md" type="text" value={href} />
       </div>
       <Button
         style={css.raw({ flex: 'none', fontSize: '14px', width: '76px' })}
-        size="sm"
+        size="md"
         type="button"
         on:click={async () => {
           try {

--- a/apps/website/src/lib/components/v2/forms/TextInput.svelte
+++ b/apps/website/src/lib/components/v2/forms/TextInput.svelte
@@ -8,7 +8,7 @@
   export let name: HTMLInputAttributes['name'] = undefined;
   export let value: HTMLInputAttributes['value'] = undefined;
   export let style: SystemStyleObject | undefined = undefined;
-  export let size: Variants['size'] = 'md';
+  export let size: Variants['size'] = 'lg';
   export let inputEl: HTMLInputElement | undefined = undefined;
   export let hidden = false;
 
@@ -33,18 +33,16 @@
       'alignItems': 'center',
       'borderWidth': '1px',
       'borderColor': 'gray.50',
-      'fontSize': '16px',
       'fontWeight': 'medium',
-      'backgroundColor': 'gray.50',
       'transition': 'common',
       '&:has(input:enabled)': {
-        borderColor: { _hover: 'gray.100', _focusWithin: 'gray.400' },
+        borderColor: { base: 'gray.100', _hover: 'gray.100', _focusWithin: 'gray.400' },
         backgroundColor: { _hover: 'gray.100', _focusWithin: 'gray.0' },
       },
       '&:has(input:disabled)': {
         color: 'gray.300',
         backgroundColor: 'gray.100',
-        borderColor: 'gray.150',
+        borderColor: 'gray.200',
       },
       '&:has(input[aria-invalid])': {
         borderColor: '[red.600!]',
@@ -54,37 +52,33 @@
     },
     variants: {
       size: {
-        xs: {
-          paddingX: '12px',
-          paddingY: '8px',
-          fontSize: '14px',
-          height: '34px',
-        },
         sm: {
           paddingX: '12px',
           paddingY: '10px',
+          fontSize: '13px',
+          height: '37px',
+        },
+        md: {
+          paddingX: '14px',
+          paddingY: '12px',
           fontSize: '14px',
           height: '44px',
         },
-        md: {
+        lg: {
           padding: '14px',
           fontSize: '14px',
           height: '48px',
-        },
-        lg: {
-          padding: '14px',
-          height: '52px',
         },
       },
     },
   });
 </script>
 
-<div class={cx(recipe({ size }), css(style))} {hidden}>
+<label class={cx(recipe({ size }), css(style))} {hidden}>
   {#if 'left-icon' in $$slots}
-    <label class={flex({ align: 'center', marginRight: '6px' })} for={name}>
+    <div class={flex({ align: 'center', marginRight: '4px' })}>
       <slot name="left-icon" />
-    </label>
+    </div>
   {/if}
 
   <input
@@ -101,8 +95,8 @@
   />
 
   {#if 'right-icon' in $$slots}
-    <label class={flex({ align: 'center', marginLeft: '6px' })} for={name}>
+    <div class={flex({ align: 'center', marginLeft: '4px' })}>
       <slot name="right-icon" />
-    </label>
+    </div>
   {/if}
-</div>
+</label>

--- a/apps/website/src/routes/(default)/SearchBar.svelte
+++ b/apps/website/src/routes/(default)/SearchBar.svelte
@@ -69,14 +69,21 @@
         await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
       }}
     >
-      <TextInput placeholder="검색어를 입력하세요" size="sm" type="search" bind:inputEl bind:value>
+      <TextInput
+        style={css.raw({ backgroundColor: 'gray.50' })}
+        placeholder="검색어를 입력하세요"
+        size="md"
+        type="search"
+        bind:inputEl
+        bind:value
+      >
         <button
           slot="left-icon"
           class={center({ transition: 'common', color: 'gray.500' })}
           aria-label="검색"
           type="submit"
         >
-          <Icon icon={IconSearch} size={20} />
+          <Icon icon={IconSearch} />
         </button>
         <button
           slot="right-icon"
@@ -85,7 +92,7 @@
           disabled={value.length === 0}
           type="reset"
         >
-          <Icon icon={IconX} size={20} />
+          <Icon icon={IconX} />
         </button>
       </TextInput>
     </form>

--- a/apps/website/src/routes/(default)/[space]/PostView.svelte
+++ b/apps/website/src/routes/(default)/[space]/PostView.svelte
@@ -1078,13 +1078,8 @@
             }
           }}
         >
-          <TextInput
-            style={css.raw({ fontSize: '14px!' })}
-            placeholder="비밀번호를 입력해주세요"
-            type="password"
-            bind:value={password}
-          />
-          <Button style={css.raw({ width: '68px' })} size="sm" type="submit">입력</Button>
+          <TextInput placeholder="비밀번호를 입력해주세요" size="lg" type="password" bind:value={password} />
+          <Button style={css.raw({ width: '68px' })} size="lg" type="submit">입력</Button>
         </form>
       </AlertText>
     {/if}

--- a/apps/website/src/routes/(default)/search/TagForm.svelte
+++ b/apps/website/src/routes/(default)/search/TagForm.svelte
@@ -48,7 +48,7 @@
     on:reset={() => (value = '')}
     use:outsideClickEvent
   >
-    <TextInput size="sm" bind:value {...$$restProps}>
+    <TextInput size="md" bind:value {...$$restProps}>
       <Icon slot="left-icon" icon={IconHash} />
       <button
         slot="right-icon"

--- a/apps/website/src/routes/editor/[permalink]/LinkModal.svelte
+++ b/apps/website/src/routes/editor/[permalink]/LinkModal.svelte
@@ -122,13 +122,7 @@
         open = false;
       }}
     >
-      <TextInput
-        style={css.raw({ marginTop: '12px', marginBottom: '26px' })}
-        size="md"
-        type="text"
-        bind:value
-        bind:inputEl
-      >
+      <TextInput style={css.raw({ marginTop: '12px', marginBottom: '26px' })} type="text" bind:value bind:inputEl>
         <Icon slot="left-icon" style={css.raw({ color: 'gray.400' })} icon={IconLink} />
       </TextInput>
 

--- a/apps/website/src/routes/editor/[permalink]/PublishMenuSearch.svelte
+++ b/apps/website/src/routes/editor/[permalink]/PublishMenuSearch.svelte
@@ -84,7 +84,7 @@
     use:outsideClickEvent
   >
     <TextInput
-      size="sm"
+      size="md"
       type="search"
       bind:value={query}
       on:blur={() => {

--- a/apps/website/src/routes/editor/[permalink]/RubyModal.svelte
+++ b/apps/website/src/routes/editor/[permalink]/RubyModal.svelte
@@ -105,13 +105,7 @@
         open = false;
       }}
     >
-      <TextInput
-        style={css.raw({ marginTop: '12px', marginBottom: '26px' })}
-        size="md"
-        type="text"
-        bind:value
-        bind:inputEl
-      >
+      <TextInput style={css.raw({ marginTop: '12px', marginBottom: '26px' })} type="text" bind:value bind:inputEl>
         <Icon slot="left-icon" style={css.raw({ color: 'gray.400' })} icon={IconRuby} />
       </TextInput>
 


### PR DESCRIPTION
- 기본 배경 색상 gray.50 -> gray.0(헤더의 검색바만 gray.50 사용함)
- 버튼과 인풋 크기 맞춤(그에 따라 TextInput의 기본 크기는 lg로, sm -> md, md-> lg로 변경)
- 인풋 안의 아이콘 크기 16으로 고정(+사이 간격 6->4로 변경)
