### PR TITLE
알림 스크린 디자인 변경사항 반영

### DIFF
--- a/apps/mobile/lib/components/empty_state.dart
+++ b/apps/mobile/lib/components/empty_state.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:glyph/themes/colors.dart';
+
+class EmptyState extends StatelessWidget {
+  const EmptyState({
+    required this.icon,
+    required this.title,
+    super.key,
+    this.description = '',
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        children: [
+          Icon(icon, size: 40),
+          const Gap(16),
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const Gap(4),
+          Text(
+            description,
+            style: TextStyle(
+              fontSize: 14,
+              color: BrandColors.gray_500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/components/pull_to_refresh.dart
+++ b/apps/mobile/lib/components/pull_to_refresh.dart
@@ -58,12 +58,14 @@ class PullToRefresh extends StatelessWidget {
     required Future<void> Function() onRefresh,
     required int itemCount,
     required NullableIndexedWidgetBuilder itemBuilder,
-    required String emptyText,
+    required IndexedWidgetBuilder separatorBuilder,
+    required Widget emptyText,
   }) {
     return PullToRefreshListView(
       onRefresh: onRefresh,
       itemCount: itemCount,
       itemBuilder: itemBuilder,
+      separatorBuilder: separatorBuilder,
       emptyText: emptyText,
     );
   }
@@ -74,14 +76,16 @@ class PullToRefreshListView extends StatelessWidget {
     required this.onRefresh,
     required this.itemCount,
     required this.itemBuilder,
+    required this.separatorBuilder,
     required this.emptyText,
     super.key,
   });
 
   final Future<void> Function() onRefresh;
   final NullableIndexedWidgetBuilder itemBuilder;
+  final IndexedWidgetBuilder separatorBuilder;
   final int itemCount;
-  final String emptyText;
+  final Widget emptyText;
 
   @override
   Widget build(BuildContext context) {
@@ -96,21 +100,14 @@ class PullToRefreshListView extends StatelessWidget {
                     constraints: BoxConstraints(
                       minHeight: constraints.maxHeight,
                     ),
-                    child: Center(
-                      child: Text(
-                        emptyText,
-                        style: const TextStyle(
-                          fontSize: 15,
-                          color: BrandColors.gray_500,
-                        ),
-                      ),
-                    ),
+                    child: emptyText,
                   ),
                 )
-              : ListView.builder(
+              : ListView.separated(
                   physics: const AlwaysScrollableScrollPhysics(),
                   itemCount: itemCount,
                   itemBuilder: itemBuilder,
+                  separatorBuilder: separatorBuilder,
                 ),
         );
       },

--- a/apps/website/src/routes/(default)/me/settings/+layout.svelte
+++ b/apps/website/src/routes/(default)/me/settings/+layout.svelte
@@ -1,30 +1,32 @@
 <script lang="ts">
   import TabHead from '$lib/components/tab/TabHead.svelte';
   import TabHeadItem from '$lib/components/tab/TabHeadItem.svelte';
+  import { isWebView } from '$lib/flutter';
   import { css } from '$styled-system/css';
 </script>
 
 <h1 class={css({ marginBottom: '20px', fontSize: '24px', fontWeight: 'bold', hideBelow: 'sm' })}>계정설정</h1>
 
-<TabHead
-  style={css.raw({
-    gap: '28px',
-    marginBottom: { base: '16px', sm: '32px' },
-    smDown: {
-      position: 'sticky',
-      top: '116px',
-      paddingY: '12px',
-      paddingX: '20px',
-      backgroundColor: 'gray.0',
-      width: 'full',
-      zIndex: '50',
-    },
-  })}
->
-  <TabHeadItem id={1} pathname="/me/settings">계정</TabHeadItem>
-  <TabHeadItem id={2} pathname="/me/settings/notifications">알림</TabHeadItem>
-</TabHead>
+{#if !$isWebView}
+  <TabHead
+    style={css.raw({
+      gap: '28px',
+      smDown: {
+        position: 'sticky',
+        top: '116px',
+        paddingY: '12px',
+        paddingX: '20px',
+        backgroundColor: 'gray.0',
+        width: 'full',
+        zIndex: '50',
+      },
+    })}
+  >
+    <TabHeadItem id={1} pathname="/me/settings">계정</TabHeadItem>
+    <TabHeadItem id={2} pathname="/me/settings/notifications">알림</TabHeadItem>
+  </TabHead>
+{/if}
 
-<div class={css({ smDown: { paddingX: '20px' } })}>
+<div class={css({ marginTop: { base: '16px', sm: '32px' }, smDown: { paddingX: '20px' } })}>
   <slot />
 </div>

--- a/apps/website/src/routes/(default)/me/settings/notifications/NotificationSwitch.svelte
+++ b/apps/website/src/routes/(default)/me/settings/notifications/NotificationSwitch.svelte
@@ -52,7 +52,6 @@
     align: 'center',
     justify: 'space-between',
     gap: '16px',
-    wrap: { base: 'wrap', sm: 'nowrap' },
   })}
 >
   <div>


### PR DESCRIPTION
- 알림 스크린 디자인 변경사항 반영
- 알림 설정 웹뷰로 띄움
- `EmptyState` 컴포넌트 추가
- `PullToRefresh`
  - separatorBuilder 사용을 위해 ListView.separated로 변경
  - emptyText에 Text 대신 EmptyState Widget이 들어가도록 수정
