### PR TITLE
알림 없을 때 문구 페이지의 중앙에 정렬함

### DIFF
--- a/apps/website/src/routes/(default)/me/notifications/+page@.svelte
+++ b/apps/website/src/routes/(default)/me/notifications/+page@.svelte
@@ -93,8 +93,17 @@
   </div>
 </header>
 
-<div class={flex({ flexDirection: 'column', flexGrow: '1', width: 'full' })}>
-  <ul class={css({ marginX: 'auto', marginBottom: '28px', minHeight: '120px', width: 'full', maxWidth: '800px' })}>
+<div class={flex({ direction: 'column', grow: '1', width: 'full' })}>
+  <ul
+    class={flex({
+      direction: 'column',
+      grow: '1',
+      marginBottom: '28px',
+      minHeight: '120px',
+      width: 'full',
+      maxWidth: '800px',
+    })}
+  >
     {#each $query.me.notifications as notification (notification.id)}
       <li>
         {#if notification.__typename === 'CommentNotification'}
@@ -108,7 +117,7 @@
         {/if}
       </li>
     {:else}
-      <p class={css({ fontSize: '15px', color: 'gray.400', textAlign: 'center' })}>알림이 없어요</p>
+      <p class={css({ marginY: 'auto', fontSize: '15px', color: 'gray.400', textAlign: 'center' })}>알림이 없어요</p>
     {/each}
   </ul>
 </div>


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
<img width="340" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/3a72b88d-8d5e-463c-9519-637fd0f1aa50">|<img width="340" alt="image" src="https://github.com/withglyph/glyph/assets/76952602/2aef9364-bd2d-46a0-a553-90b3cfe4746f">