### PR TITLE
ios 사파리에서 체크박스가 다르게 보이는 문제 수정

### DIFF
--- a/apps/website/src/lib/components/forms/Checkbox.svelte
+++ b/apps/website/src/lib/components/forms/Checkbox.svelte
@@ -46,6 +46,7 @@
         size: '13px',
         borderWidth: '1px',
         borderColor: 'gray.500',
+        borderRadius: '0',
         cursor: 'pointer',
         appearance: 'none',
         transition: 'common',


### PR DESCRIPTION
왜 마음대로 라운드를 넣는걸까