### PR TITLE
포스트 스크린에 빠진 인터랙션 추가

### DIFF
--- a/apps/mobile/lib/graphql/post_screen_delete_post_mutation.graphql
+++ b/apps/mobile/lib/graphql/post_screen_delete_post_mutation.graphql
@@ -1,0 +1,5 @@
+mutation PostScreen_DeletePost_Mutation($input: DeletePostInput!) {
+  deletePost(input: $input) {
+    id
+  }
+}

--- a/apps/mobile/lib/graphql/post_screen_follow_space_mutation.graphql
+++ b/apps/mobile/lib/graphql/post_screen_follow_space_mutation.graphql
@@ -1,0 +1,7 @@
+mutation PostScreen_FollowSpace_Mutation($input: FollowSpaceInput!) {
+  followSpace(input: $input) {
+    id
+    followed
+    followerCount
+  }
+}

--- a/apps/mobile/lib/graphql/post_screen_mute_space_mutation.graphql
+++ b/apps/mobile/lib/graphql/post_screen_mute_space_mutation.graphql
@@ -1,0 +1,6 @@
+mutation PostScreen_MuteSpace_Mutation($input: MuteSpaceInput!) {
+  muteSpace(input: $input) {
+    id
+    muted
+  }
+}

--- a/apps/mobile/lib/graphql/post_screen_query.graphql
+++ b/apps/mobile/lib/graphql/post_screen_query.graphql
@@ -22,15 +22,29 @@ query PostScreen_Query($permalink: String!) {
       slug
       name
       description
+      followed
+      muted
 
       icon  {
         id
         ...Img_image
       }
+
+      meAsMember {
+        id
+      }
     }
 
     collection {
       id
+      name
+      description
+      count
+
+      thumbnail {
+        id
+        ...Img_image
+      }
     }
 
     member {
@@ -52,6 +66,7 @@ query PostScreen_Query($permalink: String!) {
       title
       subtitle
       price
+      readingTime
     }
 
     thumbnail {

--- a/apps/mobile/lib/graphql/post_screen_unfollow_space_mutation.graphql
+++ b/apps/mobile/lib/graphql/post_screen_unfollow_space_mutation.graphql
@@ -1,0 +1,7 @@
+mutation PostScreen_UnfollowSpace_Mutation($input: UnfollowSpaceInput!) {
+  unfollowSpace(input: $input) {
+    id
+    followed
+    followerCount
+  }
+}

--- a/apps/mobile/lib/graphql/post_screen_unmute_space_mutation.graphql
+++ b/apps/mobile/lib/graphql/post_screen_unmute_space_mutation.graphql
@@ -1,0 +1,6 @@
+mutation PostScreen_UnmuteSpace_Mutation($input: UnmuteSpaceInput!) {
+  unmuteSpace(input: $input) {
+    id
+    muted
+  }
+}


### PR DESCRIPTION
- 포스트 하단에 컬렉션 정보 표시
- 스페이스 구독 버튼이 동작하도록 함
- 스페이스 터치 시 스페이스로 이동
- 읽는 시간 표시
- 더보기 메뉴(스페이스 뮤트, 수정, 삭제)
- 태그 클릭 시 태그로 이동
- 추천글 없을 때 추천 제목 표시 x
- 이전 포스트, 다음 포스트 텍스트 오버플로우될 때 두줄로 표시
- 이전/다음 포스트 부제목 없을 시 중앙정렬