### PR TITLE
fix mixpanel track properties for comment:delete

### DIFF
--- a/apps/website/src/routes/(default)/[space]/Comment.svelte
+++ b/apps/website/src/routes/(default)/[space]/Comment.svelte
@@ -529,8 +529,7 @@
           if (!$postComment.masquerade || !$query.post.space) return;
 
           mixpanel.track('comment:delete', {
-            masqueradeId: $postComment.masquerade.id,
-            spaceId: $query.post.space.id,
+            commentId: $postComment.id,
           });
 
           deleteCommentOpen = false;


### PR DESCRIPTION
코드 베끼다 발견
근데 같은 event name인데 properties가 수정되어도 문제 없나요?