### PR TITLE
설정 페이지 하단 여백

### DIFF
--- a/apps/mobile/lib/screens/settings.dart
+++ b/apps/mobile/lib/screens/settings.dart
@@ -206,6 +206,7 @@ class SettingsScreen extends ConsumerWidget {
                     ],
                   ),
                 ),
+                const Gap(80),
               ],
             ),
           );


### PR DESCRIPTION
안드로이드는 여백이 없으면 시스템바땜에 마지막 메뉴를 못 누름