### PR TITLE
Pull-to-Refresh 할 때 내용이 navbar 너머로 보이는 현상 수정

### DIFF
--- a/apps/mobile/lib/components/pull_to_refresh.dart
+++ b/apps/mobile/lib/components/pull_to_refresh.dart
@@ -46,7 +46,10 @@ class PullToRefresh extends StatelessWidget {
                 ),
               ),
             ),
-            Transform.translate(offset: Offset(0, controller.value * 60), child: child),
+            Padding(
+              padding: Pad(top: controller.value * 60),
+              child: child,
+            ),
           ],
         );
       },


### PR DESCRIPTION
![스크린샷 2024-07-11 오후 3.42.13.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9jXlt56xEAFo15LmrJ3q/81cf774a-44a8-44f3-9a88-878c1e47efd4.png)
이것을 잡았습니다

Transform.translate 대신 Padding 사용