### PR TITLE
피드의 가로 스크롤이 window의 innerWidth가 아니라 container의 clientWidth만큼 스크롤되도록 수정

### DIFF
--- a/apps/website/src/routes/(default)/(feed)/(index)/HorizontalScroll.svelte
+++ b/apps/website/src/routes/(default)/(feed)/(index)/HorizontalScroll.svelte
@@ -13,13 +13,13 @@
   const scrollLeft = () => {
     if (!containerEl) return;
 
-    containerEl.scrollLeft = containerEl.scrollLeft - (window.innerWidth - scrollOffset);
+    containerEl.scrollLeft = containerEl.scrollLeft - (containerEl.clientWidth - scrollOffset);
   };
 
   const scrollRight = () => {
     if (!containerEl) return;
 
-    containerEl.scrollLeft = containerEl.scrollLeft + (window.innerWidth - scrollOffset);
+    containerEl.scrollLeft = containerEl.scrollLeft + (containerEl.clientWidth - scrollOffset);
   };
 </script>
 


### PR DESCRIPTION
기존에는 container의 max width는 고정되어있는데 스크롤이 window.innerWidth만큼 움직여서 화면이 커질수록 스크롤이 확 넘어가는 현상이 있었음
containerEl의 clientWidth만큼만 스크롤되도록 수정함
