### PR TITLE
HTML 네이티브 렌더러 - html string으로 직접 렌더링

### DIFF
--- a/apps/mobile/lib/prosemirror/widgets/html.dart
+++ b/apps/mobile/lib/prosemirror/widgets/html.dart
@@ -1,6 +1,29 @@
+import 'package:assorted_layout_widgets/assorted_layout_widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:glyph/prosemirror/schema.dart';
-import 'package:glyph/prosemirror/special/webview.dart';
+import 'package:glyph/prosemirror/special/padded.dart';
+import 'package:glyph/themes/colors.dart';
+
+const String _getHeightJsSource = '''
+  var getHeight = function() {
+    window.flutter_inappwebview.callHandler('getHeight', document.body.scrollHeight);
+  };
+  getHeight();
+
+  var observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      getHeight();
+    });
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+  });
+''';
 
 class ProseMirrorWidgetHtml extends StatelessWidget {
   const ProseMirrorWidgetHtml({
@@ -18,6 +41,74 @@ class ProseMirrorWidgetHtml extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ProseMirrorWebView(node: node);
+    final settings = InAppWebViewSettings(
+      allowsBackForwardNavigationGestures: false,
+      disableContextMenu: true,
+      disableLongPressContextMenuOnLinks: true,
+      isTextInteractionEnabled: false,
+      disableHorizontalScroll: true,
+      disableVerticalScroll: true,
+      disallowOverScroll: true,
+      supportZoom: false,
+      transparentBackground: true,
+    );
+
+    double height = 1.0;
+
+    return ProseMirrorPadded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const DecoratedBox(
+            decoration: BoxDecoration(color: BrandColors.gray_100),
+            child: Padding(
+              padding: Pad(horizontal: 10, vertical: 5),
+              child: Text(
+                'HTML',
+                style: TextStyle(
+                  color: BrandColors.gray_400,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(color: BrandColors.gray_150),
+            ),
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                return SizedBox(
+                  height: height,
+                  child: InAppWebView(
+                    key: key,
+                    initialSettings: settings,
+                    initialData: InAppWebViewInitialData(data: node.content?.first.text ?? ''),
+                    preventGestureDelay: true,
+                    onWebViewCreated: (controller) async {
+                      controller.addJavaScriptHandler(
+                        handlerName: 'getHeight',
+                        callback: (data) {
+                          final newHeight = double.parse(data[0].toString());
+                          setState(() {
+                            height = newHeight;
+                          });
+                        },
+                      );
+                    },
+                    onLoadStop: (controller, url) async {
+                      await controller.evaluateJavascript(
+                        source: _getHeightJsSource,
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
- 웹이랑 똑같은 디자인
- html 스크롤하면 내용과 함께 부모도 스크롤되는 문제가 해결됨
- 하지만 최대 높이를 제한하지 않고 있으며 이제 html 노드 내부에 스크롤이 생기지 않음