### PR TITLE
GraphQLOperation 위젯 타이밍 이슈 해결

### DIFF
--- a/apps/mobile/lib/ferry/widget.dart
+++ b/apps/mobile/lib/ferry/widget.dart
@@ -47,6 +47,13 @@ class _GraphQLOperationState<TData, TVars> extends ConsumerState<GraphQLOperatio
   }
 
   @override
+  void dispose() {
+    _animationController.dispose();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final asyncAuth = ref.watch(authProvider);
     final asyncClient = ref.watch(ferryProvider);
@@ -94,6 +101,10 @@ class _GraphQLOperationState<TData, TVars> extends ConsumerState<GraphQLOperatio
           _loaded = true;
 
           WidgetsBinding.instance.addPostFrameCallback((_) async {
+            if (!mounted) {
+              return;
+            }
+
             unawaited(_animationController.forward());
             widget.onDataLoaded?.call(context, notifier, data);
           });


### PR DESCRIPTION
- animation controller dispose가 되고 있지 않던 문제 해결함
- post frame callback이 disposal보다 이후에 실행될 경우 발생하는 레이스 컨디션 회피함
