### PR TITLE
검색어가 있을 때만 검색 가능

### DIFF
--- a/apps/website/src/routes/(default)/SearchBar.svelte
+++ b/apps/website/src/routes/(default)/SearchBar.svelte
@@ -66,7 +66,9 @@
     <form
       class={css({ flexGrow: '1' })}
       on:submit|preventDefault={async () => {
-        await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
+        if (value) {
+          await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
+        }
       }}
     >
       <TextInput


### PR DESCRIPTION
그러나 SearchBar에서 input이 아닌 부분을 클릭하면 input에 포커스가 안 되어 검색어가 안 쳐지고 혼란스러운 문제가 남아있습니다

그냥 클릭 시 포커스를 강제로 줄 수 있지만 a11y 에러가 뜨네요
input이 SearchBar와 같은 사이즈여야 할듯!