### PR TITLE
HexColor.fromHex가 RRGGBBAA를 올바르게 파싱

### DIFF
--- a/apps/mobile/lib/extensions/color.dart
+++ b/apps/mobile/lib/extensions/color.dart
@@ -2,9 +2,23 @@ import 'dart:ui';
 
 extension HexColor on Color {
   static Color fromHex(String hexString) {
+    final hexBody = hexString.replaceFirst('#', '');
+
     final buffer = StringBuffer();
-    if (hexString.length == 6 || hexString.length == 7) buffer.write('ff');
-    buffer.write(hexString.replaceFirst('#', ''));
+
+    // write AA
+    if (hexBody.length == 6) {
+      // #RRGGBB
+      buffer.write('ff');
+    } else {
+      // #RRGGBBAA
+      buffer.write(hexBody.substring(6, 8));
+    }
+
+    // write RRGGBB
+    buffer.write(hexBody.substring(0, 6));
+
+    // parse AARRGGBB
     return Color(int.parse(buffer.toString(), radix: 16));
   }
 }


### PR DESCRIPTION
Color()가 받는 값: 0xAARRGGBB
캐로셀에 들어가는 gradient color: RRGGBB 또는 RRGGBBAA

as-is:
#RRGGBBAA를 0xAARRGGBB로서 파싱하고 있음

to-be:
제대로 파싱함