### PR TITLE
이용 가능한 연령 제한 콘텐츠가 없을 때 테이블 레이아웃이 깨지지 않도록 수정

### DIFF
--- a/apps/website/src/routes/(default)/me/settings/(index)/+page.svelte
+++ b/apps/website/src/routes/(default)/me/settings/(index)/+page.svelte
@@ -281,6 +281,7 @@
           {:else}
             <Chip style={css.raw({ width: 'fit' })} color="gray" variant="fill">미인증</Chip>
           {/if}
+          &nbsp;
         </TableData>
         <TableData>
           {$query.me.personalIdentity ? dayjs($query.me.personalIdentity.expiresAt).formatAsDate() : ''}


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
|<img width="482" alt="image" src="https://github.com/user-attachments/assets/1ce59e7a-3951-4a8d-a994-9c00b2a6e4fe">|<img width="479" alt="image" src="https://github.com/user-attachments/assets/c30fbf8b-2057-4587-80a6-113ea3369b29">|